### PR TITLE
Selection Menus (Interactions Pt. 2)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -218,7 +218,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             // @plugin dDiscordBot
             // @description
             // Returns a blank DiscordSelectionTag instance, to be filled with data via the with.as tag.
-            // Or, if given an input, returns a Discord Embed object constructed from the input value.
+            // Or, if given an input, returns a Discord Selection object constructed from the input value.
             // Refer to <@link objecttype DiscordSelectionTag>.
             // -->
             TagManager.registerTagHandler("discord_selection", (attribute) -> {

--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -45,6 +45,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordMessageReactionAddScriptEvent.instance = new DiscordMessageReactionAddScriptEvent());
             ScriptEvent.registerScriptEvent(DiscordMessageReactionRemoveScriptEvent.instance = new DiscordMessageReactionRemoveScriptEvent());
             ScriptEvent.registerScriptEvent(DiscordMessageReceivedScriptEvent.instance = new DiscordMessageReceivedScriptEvent());
+            ScriptEvent.registerScriptEvent(DiscordSelectionUsedScriptEvent.instance = new DiscordSelectionUsedScriptEvent());
             ScriptEvent.registerScriptEvent(DiscordSlashCommandScriptEvent.instance = new DiscordSlashCommandScriptEvent());
             ScriptEvent.registerScriptEvent(DiscordUserJoinsScriptEvent.instance = new DiscordUserJoinsScriptEvent());
             ScriptEvent.registerScriptEvent(DiscordUserLeavesScriptEvent.instance = new DiscordUserLeavesScriptEvent());
@@ -60,6 +61,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             ObjectFetcher.registerWithObjectFetcher(DiscordMessageTag.class, DiscordMessageTag.tagProcessor);
             ObjectFetcher.registerWithObjectFetcher(DiscordReactionTag.class, DiscordReactionTag.tagProcessor);
             ObjectFetcher.registerWithObjectFetcher(DiscordRoleTag.class, DiscordRoleTag.tagProcessor);
+            ObjectFetcher.registerWithObjectFetcher(DiscordSelectionTag.class, DiscordSelectionTag.tagProcessor);
             ObjectFetcher.registerWithObjectFetcher(DiscordUserTag.class, DiscordUserTag.tagProcessor);
             // <--[tag]
             // @attribute <discord[<bot-id>]>
@@ -209,6 +211,21 @@ public class DenizenDiscordBot extends JavaPlugin {
                     return null;
                 }
                 return DiscordRoleTag.valueOf(attribute.getContext(1), attribute.context);
+            });
+            // <--[tag]
+            // @attribute <discord_selection[(<menu>)]>
+            // @returns DiscordSelectionTag
+            // @plugin dDiscordBot
+            // @description
+            // Returns a blank DiscordSelectionTag instance, to be filled with data via the with.as tag.
+            // Or, if given an input, returns a Discord Embed object constructed from the input value.
+            // Refer to <@link objecttype DiscordSelectionTag>.
+            // -->
+            TagManager.registerTagHandler("discord_selection", (attribute) -> {
+                if (!attribute.hasContext(1)) {
+                    return new DiscordSelectionTag();
+                }
+                return DiscordSelectionTag.valueOf(attribute.getContext(1), attribute.context);
             });
             // <--[tag]
             // @attribute <discord_user[<user>]>

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -90,6 +91,11 @@ public class DiscordConnection extends ListenerAdapter {
     public void onButtonClick(ButtonClickEvent event) {
         autoHandle(event, DiscordButtonClickedScriptEvent.instance);
     }
+
+    @Override
+    public void onSelectionMenu(SelectionMenuEvent event) {
+        autoHandle(event, DiscordSelectionUsedScriptEvent.instance);
+    };
 
     public void autoHandle(Event event, DiscordScriptEvent scriptEvent) {
         Bukkit.getScheduler().runTask(DenizenDiscordBot.instance, () -> {

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordMessageCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordMessageCommand.java
@@ -16,7 +16,7 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.Component;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import org.bukkit.Bukkit;
 
@@ -147,14 +147,20 @@ public class DiscordMessageCommand extends AbstractCommand implements Holdable {
         List<ActionRow> actionRows = new ArrayList<>();
         if (rows != null) {
             for (ListTag row : rows) {
-                List<Button> buttons = new ArrayList<>();
-                for (DiscordButtonTag button : row.filter(DiscordButtonTag.class, scriptEntry.getContext())) {
-                    Button built = button.build();
+                List<Component> components = new ArrayList<>();
+                for (String component : row) {
+                    Component built = null;
+                    if (component.startsWith("discordbutton@")) {
+                        built = DiscordButtonTag.valueOf(component, scriptEntry.getContext()).build();
+                    }
+                    else if (component.startsWith("discordselection@")) {
+                        built = DiscordSelectionTag.valueOf(component, scriptEntry.getContext()).build(scriptEntry.getContext()).build();
+                    }
                     if (built != null) {
-                        buttons.add(built);
+                        components.add(built);
                     }
                 }
-                actionRows.add(ActionRow.of(buttons));
+                actionRows.add(ActionRow.of(components));
             }
             return actionRows;
         }

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
@@ -84,7 +84,6 @@ public class DiscordSelectionUsedScriptEvent extends DiscordScriptEvent {
             case "options":
                 return DiscordSelectionTag.getSelectionOptions(getEvent().getSelectedOptions());
         }
-
         return super.getContext(name);
     }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
@@ -1,0 +1,95 @@
+package com.denizenscript.ddiscordbot.events;
+
+import com.denizenscript.ddiscordbot.DiscordScriptEvent;
+import com.denizenscript.ddiscordbot.objects.DiscordChannelTag;
+import com.denizenscript.ddiscordbot.objects.DiscordGroupTag;
+import com.denizenscript.ddiscordbot.objects.DiscordInteractionTag;
+import com.denizenscript.ddiscordbot.objects.DiscordSelectionTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
+
+public class DiscordSelectionUsedScriptEvent extends DiscordScriptEvent {
+
+    public static DiscordSelectionUsedScriptEvent instance;
+
+    // <--[event]
+    // @Events
+    // discord selection used
+    //
+    // @Regex ^on discord selection used$
+    //
+    // @Switch for:<bot> to only process the event for a specified Discord bot.
+    // @Switch channel:<channel_id> to only process the event when it occurs in a specified Discord channel.
+    // @Switch group:<group_id> to only process the event for a specified Discord group.
+    // @Switch id:<menu_id> to only process the event for a specified Discord selection menu.
+    //
+    // @Triggers when a Discord user uses a selection menu.
+    //
+    // @Plugin dDiscordBot
+    //
+    // @Group Discord
+    //
+    // @Context
+    // <context.bot> returns the relevant Discord bot object.
+    // <context.channel> returns the channel.
+    // <context.group> returns the group.
+    // <context.interaction> returns the interaction.
+    // <context.menu> returns the selection menu.
+    // <context.options> returns the selected options.
+    //
+    // -->
+
+    public SelectionMenuEvent getEvent() {
+        return (SelectionMenuEvent) event;
+    }
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventLower.startsWith("discord selection used");
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!path.checkSwitch("channel", getEvent().getChannel().getId())) {
+            return false;
+        }
+        if (path.switches.containsKey("group")) {
+            if (!getEvent().isFromGuild()) {
+                return false;
+            }
+            if (!path.checkSwitch("group", getEvent().getGuild().getId())) {
+                return false;
+            }
+        }
+        if (!path.checkSwitch("id", getEvent().getSelectionMenu().getId())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "channel":
+                return new DiscordChannelTag(botID, getEvent().getChannel());
+            case "group":
+                if (getEvent().isFromGuild()) {
+                    return new DiscordGroupTag(botID, getEvent().getGuild());
+                }
+                break;
+            case "interaction":
+                return DiscordInteractionTag.getOrCreate(botID, getEvent().getInteraction());
+            case "menu":
+                return new DiscordSelectionTag(getEvent().getSelectionMenu());
+            case "options":
+                return DiscordSelectionTag.getSelectionOptions(getEvent().getSelectedOptions());
+        }
+
+        return super.getContext(name);
+    }
+
+    @Override
+    public String getName() {
+        return "DiscordSelectionUsed";
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
@@ -35,7 +35,7 @@ public class DiscordSelectionUsedScriptEvent extends DiscordScriptEvent {
     // <context.group> returns the group.
     // <context.interaction> returns the interaction.
     // <context.menu> returns the selection menu.
-    // <context.options> returns the selected options.
+    // <context.option> returns the selected option.
     //
     // -->
 
@@ -81,8 +81,8 @@ public class DiscordSelectionUsedScriptEvent extends DiscordScriptEvent {
                 return DiscordInteractionTag.getOrCreate(botID, getEvent().getInteraction());
             case "menu":
                 return new DiscordSelectionTag(getEvent().getSelectionMenu());
-            case "options":
-                return DiscordSelectionTag.getSelectionOptions(getEvent().getSelectedOptions());
+            case "option":
+                return DiscordSelectionTag.getSelectionOption(getEvent().getSelectedOptions().get(0));
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordButtonTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordButtonTag.java
@@ -51,7 +51,7 @@ public class DiscordButtonTag implements ObjectTag {
     }
 
     public static boolean matches(String arg) {
-        if (arg.startsWith("discordembed@")) {
+        if (arg.startsWith("discordbutton@")) {
             return true;
         }
         return MapTag.matches(arg);
@@ -195,7 +195,7 @@ public class DiscordButtonTag implements ObjectTag {
         // @returns MapTag
         // @plugin dDiscordBot
         // @description
-        // Returns the MapTag internally backing this embed tag.
+        // Returns the MapTag internally backing this button tag.
         // -->
         registerTag("map", (attribute, object) -> {
             return object.buttonData.duplicate();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -1,0 +1,283 @@
+package com.denizenscript.ddiscordbot.objects;
+
+import com.denizenscript.denizencore.objects.Fetchable;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.tags.TagRunnable;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.text.StringHolder;
+import net.dv8tion.jda.api.entities.Emoji;
+import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
+import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class DiscordSelectionTag implements ObjectTag {
+
+    // <--[ObjectType]
+    // @name DiscordSelectionTag
+    // @prefix discordselection
+    // @base ElementTag
+    // @format
+    // The identity format for Discord selection menu is a map of menu data. Do not alter raw menu data, use the with.as tag instead.
+    //
+    // @plugin dDiscordBot
+    // @description
+    // A DiscordSelectionTag is an object that represents a Discord selection menu for use with dDiscordBot.
+    //
+    // -->
+
+    @Fetchable("discordselection")
+    public static DiscordSelectionTag valueOf(String string, TagContext context) {
+        if (string.startsWith("discordselection@")) {
+            string = string.substring("discordselection@".length());
+        }
+        MapTag map = MapTag.valueOf(string, context);
+        if (map == null) {
+            return null;
+        }
+        return new DiscordSelectionTag(map);
+    }
+
+    @Override
+    public DiscordSelectionTag duplicate() {
+        return new DiscordSelectionTag(menuData.duplicate());
+    }
+
+    public static boolean matches(String arg) {
+        if (arg.startsWith("discordselection@")) {
+            return true;
+        }
+        return MapTag.matches(arg);
+    }
+
+    public DiscordSelectionTag() {
+        menuData = new MapTag();
+    }
+
+    public DiscordSelectionTag(MapTag map) {
+        menuData = map;
+    }
+
+    public static MapTag getSelectionOptions(List<SelectOption> selectOptions) {
+        MapTag options = new MapTag();
+        if (selectOptions != null) {
+            for (SelectOption option : selectOptions) {
+                options.putObject("label", new ElementTag(option.getLabel()));
+                options.putObject("value", new ElementTag(option.getValue()));
+                if (option.getDescription() != null) {
+                    options.putObject("description", new ElementTag(option.getDescription()));
+                }
+                if (option.getEmoji() != null) {
+                    options.putObject("emoji", new ElementTag(option.getEmoji().getName()));
+                }
+            }
+        }
+        return options;
+    }
+
+    public DiscordSelectionTag(SelectionMenu menu) {
+        menuData = new MapTag();
+        if (menu.getId() != null) {
+            menuData.putObject("id", new ElementTag(menu.getId()));
+        }
+        menuData.putObject("options", DiscordSelectionTag.getSelectionOptions(menu.getOptions()));
+    }
+
+    public SelectionMenu.Builder build(TagContext context) {
+        ObjectTag id = menuData.getObject("id");
+        MapTag options = (MapTag) menuData.getObject("options");
+        SelectionMenu.Builder menu = null;
+        if (id != null) {
+            menu = SelectionMenu.create(id.toString());
+        }
+        else {
+            return null;
+        }
+        if (options != null) {
+            for (ObjectTag optionObj : options.map.values()) {
+                MapTag option = optionObj.asType(MapTag.class, context);
+                ElementTag label = (ElementTag) option.getObject("label");
+                ElementTag value = (ElementTag) option.getObject("value");
+                ElementTag description = (ElementTag) option.getObject("description");
+                ElementTag emoji = (ElementTag) option.getObject("emoji");
+                Emoji emojiData = null;
+                if (emoji != null) {
+                    emojiData = Emoji.fromUnicode(emoji.toString());
+                }
+                if (label == null || value == null) {
+                    return null;
+                }
+                if (description == null && emoji == null) {
+                    menu.addOption(label.toString(), value.toString());
+                }
+                else if (emoji == null) {
+                    menu.addOption(label.toString(), value.toString(), description.toString());
+                }
+                else if (description == null) {
+                    if (emojiData != null) {
+                        menu.addOption(label.toString(), value.toString(), emojiData);
+                    }
+                }
+                else {
+                    if (emojiData != null) {
+                        menu.addOption(label.toString(), value.toString(), description.toString(), emojiData);
+                    }
+                }
+            }
+        }
+        return menu;
+    }
+
+    public MapTag menuData;
+
+    public static HashSet<String> acceptedWithKeys = new HashSet<>(Arrays.asList(
+        "id", "options"
+    ));
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <DiscordSelectionTag.with_map[<map>]>
+        // @returns DiscordSelectionTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns a copy of this Button tag, with the map of keys to values applied.
+        // Refer to <@link tag DiscordSelectionTag.with.as>.
+        // -->
+        registerTag("with_map", (attribute, object) -> {
+            DiscordSelectionTag menu = object.duplicate();
+            if (!attribute.hasContext(1)) {
+                attribute.echoError("Invalid selection.with_map[...] tag: must have an input value.");
+                return null;
+            }
+            MapTag map = MapTag.getMapFor(attribute.getContextObject(1), attribute.context);
+            for (Map.Entry<StringHolder, ObjectTag> entry : map.map.entrySet()) {
+                String key = entry.getKey().low;
+                if (!acceptedWithKeys.contains(key)) {
+                    attribute.echoError("Invalid selection.with_map[...] tag: unknown key '" + key + "' given.");
+                    return null;
+                }
+                ObjectTag val = entry.getValue();
+                if (val == null) {
+                    attribute.echoError("selection.with_map[...] value is invalid.");
+                    return null;
+                }
+                menu.menuData.putObject(key, val);
+            }
+            return menu;
+        });
+
+        // <--[tag]
+        // @attribute <DiscordSelectionTag.with[<key>].as[<value>]>
+        // @returns DiscordSelectionTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns a copy of this Selection tag, with the specified data key set to the specified value.
+        // The following keys are accepted, with values of the listed type:
+        // id: ElementTag
+        // options: MapTag where the values are also a MapTag consisting of:
+        // - label: ElementTag
+        // - value: ElementTag
+        // - description: ElementTag
+        // - emoji: ElementTag
+        // -->
+        registerTag("with", (attribute, object) -> {
+            DiscordSelectionTag menu = object.duplicate();
+            if (!attribute.hasContext(1)) {
+                attribute.echoError("Invalid selection.with[...] tag: must have an input value.");
+                return null;
+            }
+            String key = CoreUtilities.toLowerCase(attribute.getContext(1));
+            if (!acceptedWithKeys.contains(key)) {
+                attribute.echoError("Invalid selection.with[...] tag: unknown key '" + key + "' given.");
+                return null;
+            }
+            attribute.fulfill(1);
+            if (!attribute.startsWith("as") || !attribute.hasContext(1)) {
+                attribute.echoError("selection.with[...] must be followed by as[...].");
+            }
+            ObjectTag val = attribute.getContextObject(1);
+            if (val == null) {
+                attribute.echoError("selection.with[...].as[...] value is invalid.");
+                return null;
+            }
+            menu.menuData.putObject(key, val);
+            return menu;
+        });
+
+        // <--[tag]
+        // @attribute <DiscordSelectionTag.map>
+        // @returns MapTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns the MapTag internally backing this selection tag.
+        // -->
+        registerTag("map", (attribute, object) -> {
+            return object.menuData.duplicate();
+        });
+    }
+
+    public static ObjectTagProcessor<DiscordSelectionTag> tagProcessor = new ObjectTagProcessor<>();
+
+    public static void registerTag(String name, TagRunnable.ObjectInterface<DiscordSelectionTag> runnable, String... variants) {
+        tagProcessor.registerTag(name, runnable, variants);
+    }
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    String prefix = "discordselection";
+
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @Override
+    public String debuggable() {
+        return "discordselection@" + menuData.debuggable();
+    }
+
+    @Override
+    public boolean isUnique() {
+        return false;
+    }
+
+    @Override
+    public String getObjectType() {
+        return "DiscordSelection";
+    }
+
+    @Override
+    public String identify() {
+        return "discordselection@" + menuData.identify();
+    }
+
+    @Override
+    public String identifySimple() {
+        return identify();
+    }
+
+    @Override
+    public String toString() {
+        return identify();
+    }
+
+    @Override
+    public ObjectTag setPrefix(String prefix) {
+        if (prefix != null) {
+            this.prefix = prefix;
+        }
+        return this;
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -80,22 +80,18 @@ public class DiscordSelectionTag implements ObjectTag {
         return options;
     }
 
-    public static ListTag getSelectionOptions(List<SelectOption> selectOptions) {
-        ListTag optionList = new ListTag();
-        if (selectOptions != null) {
-            for (SelectOption option : selectOptions) {
-                optionList.addObject(getSelectionOption(option));
-            }
-        }
-        return optionList;
-    }
-
     public DiscordSelectionTag(SelectionMenu menu) {
         menuData = new MapTag();
         if (menu.getId() != null) {
             menuData.putObject("id", new ElementTag(menu.getId()));
         }
-        menuData.putObject("options", DiscordSelectionTag.getSelectionOptions(menu.getOptions()));
+        ListTag options = new ListTag();
+        if (menu.getOptions() != null) {
+            for (SelectOption option : menu.getOptions()) {
+                options.addObject(DiscordSelectionTag.getSelectionOption(option));
+            }
+        }
+        menuData.putObject("options", options);
     }
 
     public SelectionMenu.Builder build(TagContext context) {

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -3,6 +3,7 @@ package com.denizenscript.ddiscordbot.objects;
 import com.denizenscript.denizencore.objects.Fetchable;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
@@ -66,10 +67,11 @@ public class DiscordSelectionTag implements ObjectTag {
         menuData = map;
     }
 
-    public static MapTag getSelectionOptions(List<SelectOption> selectOptions) {
-        MapTag options = new MapTag();
+    public static ListTag getSelectionOptions(List<SelectOption> selectOptions) {
+        ListTag optionList = new ListTag();
         if (selectOptions != null) {
             for (SelectOption option : selectOptions) {
+                MapTag options = new MapTag();
                 options.putObject("label", new ElementTag(option.getLabel()));
                 options.putObject("value", new ElementTag(option.getValue()));
                 if (option.getDescription() != null) {
@@ -78,9 +80,10 @@ public class DiscordSelectionTag implements ObjectTag {
                 if (option.getEmoji() != null) {
                     options.putObject("emoji", new ElementTag(option.getEmoji().getName()));
                 }
+                optionList.addObject(options);
             }
         }
-        return options;
+        return optionList;
     }
 
     public DiscordSelectionTag(SelectionMenu menu) {

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -67,20 +67,24 @@ public class DiscordSelectionTag implements ObjectTag {
         menuData = map;
     }
 
+    public static MapTag getSelectionOption(SelectOption selectOption) {
+        MapTag options = new MapTag();
+        options.putObject("label", new ElementTag(selectOption.getLabel()));
+        options.putObject("value", new ElementTag(selectOption.getValue()));
+        if (selectOption.getDescription() != null) {
+            options.putObject("description", new ElementTag(selectOption.getDescription()));
+        }
+        if (selectOption.getEmoji() != null) {
+            options.putObject("emoji", new ElementTag(selectOption.getEmoji().getName()));
+        }
+        return options;
+    }
+
     public static ListTag getSelectionOptions(List<SelectOption> selectOptions) {
         ListTag optionList = new ListTag();
         if (selectOptions != null) {
             for (SelectOption option : selectOptions) {
-                MapTag options = new MapTag();
-                options.putObject("label", new ElementTag(option.getLabel()));
-                options.putObject("value", new ElementTag(option.getValue()));
-                if (option.getDescription() != null) {
-                    options.putObject("description", new ElementTag(option.getDescription()));
-                }
-                if (option.getEmoji() != null) {
-                    options.putObject("emoji", new ElementTag(option.getEmoji().getName()));
-                }
-                optionList.addObject(options);
+                optionList.addObject(getSelectionOption(option));
             }
         }
         return optionList;

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -152,7 +152,7 @@ public class DiscordSelectionTag implements ObjectTag {
         // @returns DiscordSelectionTag
         // @plugin dDiscordBot
         // @description
-        // Returns a copy of this Button tag, with the map of keys to values applied.
+        // Returns a copy of this Selection tag, with the map of keys to values applied.
         // Refer to <@link tag DiscordSelectionTag.with.as>.
         // -->
         registerTag("with_map", (attribute, object) -> {


### PR DESCRIPTION
Tested pretty thoroughly.

A lot less than the last one, but I just wanted to get this added first before I move onto recursive subcommands.

## Design Challenges
- I mentioned this in the Discord, but naming was an issue here. I chose `DiscordSelectionTag`, and used `menu` as an abbreviation **when in relevant context**.