### PR TITLE
Further voice channel support

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -398,6 +398,27 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
                 return null;
             }
         });
+
+        // <--[tag]
+        // @attribute <DiscordChannelTag.connected_users>
+        // @returns ListTag(DiscordUserTag)
+        // @plugin dDiscordBot
+        // @description
+        // If the channel is a voice channel, returns the users connected to it.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "connected_users", (attribute, object) -> {
+            Channel channel = object.getChannel();
+            if (!(channel instanceof AudioChannel)) {
+                attribute.echoError("Cannot get 'connected_users' tag: this channel is not a voice channel.");
+                return null;
+            }
+            AudioChannel audioChannel = (AudioChannel) channel;
+            ListTag result = new ListTag();
+            for (Member member : audioChannel.getMembers()) {
+                result.addObject(new DiscordUserTag(object.bot, member.getUser()));
+            }
+            return result;
+        });
     }
 
     public static ObjectTagProcessor<DiscordChannelTag> tagProcessor = new ObjectTagProcessor<>();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -162,7 +162,7 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject {
         // -->
         tagProcessor.registerTag(ListTag.class, "channels", (attribute, object) -> {
             ListTag list = new ListTag();
-            for (TextChannel chan : object.getGuild().getTextChannels()) {
+            for (GuildChannel chan : object.getGuild().getChannels()) {
                 list.addObject(new DiscordChannelTag(object.bot, chan));
             }
             return list;
@@ -257,8 +257,8 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject {
                 return null;
             }
             String matchString = CoreUtilities.toLowerCase(attribute.getParam());
-            TextChannel bestMatch = null;
-            for (TextChannel chan : object.getGuild().getTextChannels()) {
+            GuildChannel bestMatch = null;
+            for (GuildChannel chan : object.getGuild().getChannels()) {
                 String chanName = CoreUtilities.toLowerCase(chan.getName());
                 if (matchString.equals(chanName)) {
                     bestMatch = chan;


### PR DESCRIPTION
## Additions
- Updated `DiscordGroupTag.channels` and `.channel` to support all guild channel types
- `DiscordChannelTag.connected_users` tag (voice-channel specific)
- `DiscordUserTag.move` mech to move a user to another voice channel if they're connected to one already

### Notes
- First change is slightly experimental but it's required to be able to use the `move` mech