### PR TITLE
+ discordroletag.permissions, discordusertag.permissions[group]

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
@@ -220,6 +220,21 @@ public class DiscordRoleTag implements ObjectTag, FlaggableObject {
             }
             return new ColorTag(color.getRed(), color.getGreen(), color.getBlue());
         });
+        
+        // <--[tag]
+        // @attribute <DiscordRoleTag.permissions>
+        // @returns ListTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns a list of permissions that the role provides for users. You can get a list of possible outputs here: <@link url https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html>
+        // -->
+        tagProcessor.registerTag(ListTag.class, "permissions", (attribute, object) -> {
+            ListTag list = new ListTag();
+            for (Permission perm : object.role.getPermissions()) {
+                list.addObject(new ElementTag(perm.name(), true));
+            }
+            return list;
+        });
     }
 
     public static ObjectTagProcessor<DiscordRoleTag> tagProcessor = new ObjectTagProcessor<>();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -412,7 +412,7 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
             }
             ListTag list = new ListTag();
             for (Permission perm : group.getGuild().getMember(object.getUser()).getPermissions()) {
-                list.addObject(new ElementTag(perm.name()));
+                list.addObject(new ElementTag(perm.name(), true));
             }
             return list;
         });

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -391,6 +391,31 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
             }
             return list;
         });
+        
+        // <--[tag]
+        // @attribute <DiscordUserTag.permissions[<group>]>
+        // @returns ListTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns a list of permissions that the user has in a certain group. You can get a list of possible outputs here: <@link url https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html>
+        // -->
+        tagProcessor.registerTag(ListTag.class, "permissions", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                return null;
+            }
+            DiscordGroupTag group = attribute.paramAsType(DiscordGroupTag.class);
+            if (group == null) {
+                return null;
+            }
+            if (object.getUserForTag(attribute) == null) {
+                return null;
+            }
+            ListTag list = new ListTag();
+            for (Permission perm : group.getGuild().getMember(object.getUser()).getPermissions()) {
+                list.addObject(new ElementTag(perm.name()));
+            }
+            return list;
+        });
     }
 
     public static ObjectTagProcessor<DiscordUserTag> tagProcessor = new ObjectTagProcessor<>();


### PR DESCRIPTION
# Additions
* `<DiscordRoleTag.permissions>` - Returns a list of permissions that the role provides for users. You can get a list of possible outputs here: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html
* `<DiscordUserTag.permissions[<group>]>` - Returns a list of permissions that the user has in a certain group. You can get a list of possible outputs here: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html

# Remarks
* `<DiscordUserTag.permissions[<group>]>` can technically be already done via checking through the user's roles. Therefore, this is only a "convenience tag".
* My commit on the fork says `discordroletag.permissions[group]`. This is a typo, there is no `group` attribute in this tag.
