### PR TITLE
Command Option Autocomplete Functionality

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -62,9 +62,11 @@ public class DenizenDiscordBot extends JavaPlugin {
             DenizenCore.commandRegistry.registerCommand(DiscordModalCommand.class);
             DenizenCore.commandRegistry.registerCommand(DiscordReactCommand.class);
             // Events
+            ScriptEvent.registerScriptEvent(DiscordApplicationCommandScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordButtonClickedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordChannelCreateScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordChannelDeleteScriptEvent.class);
+            ScriptEvent.registerScriptEvent(DiscordCommandAutocompleteScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageDeletedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageModifiedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageReactionAddScriptEvent.class);
@@ -72,7 +74,6 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordMessageReceivedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordModalSubmittedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordSelectionUsedScriptEvent.class);
-            ScriptEvent.registerScriptEvent(DiscordApplicationCommandScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordThreadArchivedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordThreadRevealedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserJoinsScriptEvent.class);

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -15,6 +15,7 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
@@ -29,6 +30,7 @@ import net.dv8tion.jda.api.events.thread.ThreadHiddenEvent;
 import net.dv8tion.jda.api.events.thread.ThreadRevealedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
@@ -132,6 +134,11 @@ public class DiscordConnection extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         autoHandle(event, DiscordApplicationCommandScriptEvent.instance);
+    }
+
+    @Override
+    public void onCommandAutoCompleteInteraction(CommandAutoCompleteInteractionEvent event) {
+        autoHandle(event, DiscordCommandAutocompleteScriptEvent.instance);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordApplicationCommandScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordApplicationCommandScriptEvent.java
@@ -1,20 +1,9 @@
 package com.denizenscript.ddiscordbot.events;
 
-import com.denizenscript.ddiscordbot.DiscordScriptEvent;
-import com.denizenscript.ddiscordbot.objects.DiscordChannelTag;
-import com.denizenscript.ddiscordbot.objects.DiscordCommandTag;
-import com.denizenscript.ddiscordbot.objects.DiscordGroupTag;
-import com.denizenscript.ddiscordbot.objects.DiscordInteractionTag;
-import com.denizenscript.ddiscordbot.objects.DiscordRoleTag;
-import com.denizenscript.ddiscordbot.objects.DiscordUserTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.MapTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
 
-public class DiscordApplicationCommandScriptEvent extends DiscordScriptEvent {
+public class DiscordApplicationCommandScriptEvent extends DiscordCommandInteractionScriptEvent {
 
     // <--[event]
     // @Events
@@ -46,78 +35,19 @@ public class DiscordApplicationCommandScriptEvent extends DiscordScriptEvent {
     public DiscordApplicationCommandScriptEvent() {
         instance = this;
         registerCouldMatcher("discord application|slash|message|user command");
-        registerSwitches("channel", "group", "name");
     }
 
-    public GenericCommandInteractionEvent getEvent() {
-        return (GenericCommandInteractionEvent) event;
+    @Override
+    public CommandInteractionPayload getPayload() {
+        return ((GenericCommandInteractionEvent) event).getInteraction();
     }
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!tryChannel(path, getEvent().getChannel())) {
-            return false;
-        }
-        if (!tryGuild(path, getEvent().isFromGuild() ? getEvent().getGuild() : null)) {
-            return false;
-        }
         String type = path.eventArgLowerAt(1);
-        if (!type.equals("application") && !runGenericCheck(type, getEvent().getCommandType().name())) {
-            return false;
-        }
-        if (!runGenericSwitchCheck(path, "name", CoreUtilities.replace(getEvent().getName(), " ", "_"))) {
+        if (!type.equals("application") && !runGenericCheck(type, getPayload().getCommandType().name())) {
             return false;
         }
         return super.matches(path);
-    }
-
-    @Override
-    public ObjectTag getContext(String name) {
-        switch (name) {
-            case "channel":
-                return new DiscordChannelTag(botID, getEvent().getChannel());
-            case "group":
-                if (getEvent().isFromGuild()) {
-                    return new DiscordGroupTag(botID, getEvent().getGuild());
-                }
-                break;
-            case "interaction":
-                return DiscordInteractionTag.getOrCreate(botID, getEvent().getInteraction());
-            case "command":
-                return new DiscordCommandTag(botID, getEvent().isFromGuild() ? getEvent().getGuild().getIdLong() : 0, getEvent().getCommandIdLong());
-            case "options": {
-                MapTag options = new MapTag();
-                for (OptionMapping mapping : getEvent().getOptions()) {
-                    ObjectTag result;
-                    switch (mapping.getType()) {
-                        case STRING:
-                        case SUB_COMMAND:
-                        case SUB_COMMAND_GROUP:
-                            result = new ElementTag(mapping.getAsString()); break;
-                        case BOOLEAN: result = new ElementTag(mapping.getAsBoolean()); break;
-                        case INTEGER: result = new ElementTag(mapping.getAsLong()); break;
-                        case NUMBER: result = new ElementTag(mapping.getAsDouble()); break;
-                        case ATTACHMENT: result = new ElementTag(mapping.getAsAttachment().getUrl()); break;
-                        case CHANNEL: result = new DiscordChannelTag(botID, mapping.getAsChannel()); break;
-                        case MENTIONABLE: {
-                            String mention = mapping.getAsMentionable().getAsMention();
-                            if (mention.startsWith("<@&")) {
-                                result = new DiscordRoleTag(botID, getEvent().getGuild().getIdLong(), mapping.getAsMentionable().getIdLong());
-                            }
-                            else {
-                                result = new DiscordUserTag(botID, mapping.getAsMentionable().getIdLong());
-                            }
-                            break;
-                        }
-                        case ROLE: result = new DiscordRoleTag(botID, mapping.getAsRole()); break;
-                        case USER: result = new DiscordUserTag(botID, mapping.getAsUser()); break;
-                        default: result = new ElementTag(botID, null);
-                    }
-                    options.putObject(mapping.getName(), result);
-                }
-                return options;
-            }
-        }
-        return super.getContext(name);
     }
 }

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.Command;
@@ -103,8 +104,8 @@ public class DiscordCommandAutocompleteScriptEvent extends DiscordCommandInterac
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         if (determinationObj instanceof ElementTag) {
-            String determination = ((ElementTag) determinationObj).asLowerString();
-            if (determination.startsWith("choices:")) {
+            String determination = ((ElementTag) determinationObj).asString();
+            if (CoreUtilities.toLowerCase(determination).startsWith("choices:")) {
                 ListTag list = ListTag.valueOf(determination.substring("choices:".length()), getTagContext(path));
                 if (list.size() > 25) {
                     Debug.echoError("Cannot suggest more than 25 choices!");

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
@@ -44,15 +44,17 @@ public class DiscordCommandAutocompleteScriptEvent extends DiscordCommandInterac
     // "CHOICES:" + ListTag to suggest values to the Discord client. Up to 25 suggestions are allowed to be sent. Each entry can be an ElementTag which controls both the value and display of the choice or a MapTag with "name" and "value" keys to control both separately.
     //
     // @Example
-    // # Suggests three random fruits for the "fruit" option.
+    // # Suggests fruits that are only longer in length than the current input.
     // on discord command autocomplete name:eat option:fruit:
-    // - determine choices:<list[apple|orange|lemon|banana|grape].random[3]>
+    // - define length <context.options.get[fruit].length>
+    // - define fruits <list[lime|apple|orange|blueberry|dragonfruit]>
+    // - determine choices:<[fruits].filter_tag[<[filter_value].length.is_more_than[<[length]>]>]>
     //
     // @Example
-    // # Suggests no more than 25 selections from some dataset that begin with the current input.
+    // # Suggests the 25 best-matching selections from some dataset against the current input.
     // on discord command autocomplete:
     // - define value <context.options.get[<context.focused_option>]>
-    // - determine choices:<server.flag[dataset].filter_tag[<[filter_value].starts_with[<[value]>]>].random[25]>
+    // - determine choices:<server.flag[dataset].sort_by_number[difference[<[value]>]].first[25].if_null[<list>]>
     //
     // -->
 

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandAutocompleteScriptEvent.java
@@ -1,0 +1,109 @@
+package com.denizenscript.ddiscordbot.events;
+
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DiscordCommandAutocompleteScriptEvent extends DiscordCommandInteractionScriptEvent {
+
+    // <--[event]
+    // @Events
+    // discord command autocomplete
+    //
+    // @Switch for:<bot> to only process the event for a specified Discord bot.
+    // @Switch channel:<channel_id> to only process the event when it occurs in a specified Discord channel.
+    // @Switch group:<group_id> to only process the event for a specified Discord group.
+    // @Switch name:<command_name> to only process the event for a specified Discord application command. Spaces are replaced with underscores.
+    // @Switch option:<option_name> to only process the event for a specified autocompletable option.
+    //
+    // @Triggers when a Discord user queries a slash command option that can be autocompleted.
+    //
+    // @Plugin dDiscordBot
+    //
+    // @Group Discord
+    //
+    // @Context
+    // <context.bot> returns the relevant DiscordBotTag.
+    // <context.channel> returns the DiscordChannelTag.
+    // <context.group> returns the DiscordGroupTag.
+    // <context.interaction> returns the DiscordInteractionTag.
+    // <context.command> returns the DiscordCommandTag.
+    // <context.options> returns the supplied options as a MapTag.
+    // <context.focused_option> returns the name of the focused option.
+    //
+    // @Determine
+    // ListTag to suggest values to the Discord client. Each entry can be an ElementTag which controls both the value and display of the choice or a MapTag with "name" and "value" keys to control both separately.
+    //
+    // -->
+
+    public static DiscordCommandAutocompleteScriptEvent instance;
+
+    public DiscordCommandAutocompleteScriptEvent() {
+        instance = this;
+        registerCouldMatcher("discord command autocomplete");
+        registerSwitches("option");
+    }
+
+    public CommandAutoCompleteInteractionEvent getAutocompleteEvent() {
+        return (CommandAutoCompleteInteractionEvent) event;
+    }
+
+    @Override
+    public CommandInteractionPayload getPayload() {
+        return getAutocompleteEvent().getInteraction();
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "option", getAutocompleteEvent().getFocusedOption().getName())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "focused_option":
+                return new ElementTag(getAutocompleteEvent().getFocusedOption().getName(), true);
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determination) {
+        if (!determination.canBeType(ListTag.class)) {
+            return super.applyDetermination(path, determination);
+        }
+        ListTag list = determination.asType(ListTag.class, getTagContext(path));
+        if (list.size() > 25) {
+            Debug.echoError("Cannot suggest more than 25 choices!");
+            return false;
+        }
+        List<Command.Choice> choices = new ArrayList<>();
+        for (ObjectTag objectTag : list.objectForms) {
+            Command.Choice choice;
+            if (MapTag.matches(objectTag.toString())) {
+                MapTag map = MapTag.valueOf(objectTag.toString(), getTagContext(path));
+                String name = map.getElement("name").asString();
+                String value = map.getElement("value").asString();
+                choice = new Command.Choice(name, value);
+            }
+            else {
+                String value = objectTag.toString();
+                choice = new Command.Choice(value, value);
+            }
+            choices.add(choice);
+        }
+        getAutocompleteEvent().replyChoices(choices).queue();
+        return true;
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandInteractionScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordCommandInteractionScriptEvent.java
@@ -1,0 +1,90 @@
+package com.denizenscript.ddiscordbot.events;
+
+import com.denizenscript.ddiscordbot.DiscordScriptEvent;
+import com.denizenscript.ddiscordbot.objects.*;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+
+public abstract class DiscordCommandInteractionScriptEvent extends DiscordScriptEvent {
+
+    public DiscordCommandInteractionScriptEvent() {
+        registerSwitches("channel", "group", "name");
+    }
+
+    public GenericInteractionCreateEvent getEvent() {
+        return (GenericInteractionCreateEvent) event;
+    }
+
+    // Least verbose abstraction of command/autocomplete event data
+    public abstract CommandInteractionPayload getPayload();
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!tryChannel(path, getEvent().getChannel())) {
+            return false;
+        }
+        if (!tryGuild(path, getEvent().isFromGuild() ? getEvent().getGuild() : null)) {
+            return false;
+        }
+        if (!runGenericSwitchCheck(path, "name", CoreUtilities.replace(getPayload().getName(), " ", "_"))) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    public ObjectTag getOptionAsObject(OptionMapping option) {
+        switch (option.getType()) {
+            case STRING:
+            case SUB_COMMAND:
+            case SUB_COMMAND_GROUP:
+                return new ElementTag(option.getAsString());
+            case BOOLEAN: return new ElementTag(option.getAsBoolean());
+            case INTEGER: return new ElementTag(option.getAsLong());
+            case NUMBER: return new ElementTag(option.getAsDouble());
+            case ATTACHMENT: return new ElementTag(option.getAsAttachment().getUrl());
+            case CHANNEL: return new DiscordChannelTag(botID, option.getAsChannel());
+            case MENTIONABLE: {
+                String mention = option.getAsMentionable().getAsMention();
+                if (mention.startsWith("<@&")) {
+                    return new DiscordRoleTag(botID, getEvent().getGuild().getIdLong(), option.getAsMentionable().getIdLong());
+                }
+                else {
+                    return new DiscordUserTag(botID, option.getAsMentionable().getIdLong());
+                }
+            }
+            case ROLE: return new DiscordRoleTag(botID, option.getAsRole());
+            case USER: return new DiscordUserTag(botID, option.getAsUser());
+            default: return new ElementTag(botID, null);
+        }
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "channel":
+                return new DiscordChannelTag(botID, getEvent().getChannel());
+            case "group":
+                if (getEvent().isFromGuild()) {
+                    return new DiscordGroupTag(botID, getEvent().getGuild());
+                }
+                break;
+            case "interaction":
+                return DiscordInteractionTag.getOrCreate(botID, getEvent().getInteraction());
+            case "command":
+                return new DiscordCommandTag(botID, getEvent().isFromGuild() ? getEvent().getGuild().getIdLong() : 0, getPayload().getCommandIdLong());
+            case "options": {
+                MapTag options = new MapTag();
+                for (OptionMapping mapping : getPayload().getOptions()) {
+                    options.putObject(mapping.getName(), getOptionAsObject(mapping));
+                }
+                return options;
+            }
+        }
+        return super.getContext(name);
+    }
+}


### PR DESCRIPTION
## Additions

- New event: `discord command autocomplete`
  - Determination controls option suggestions for the Discord client
- `discordcommand` command options now have an optional `autocomplete` key for whether they can be autocompleted

### Notes

- `discord command autocomplete` and `discord application command` events shared the majority of their context and switches. They have been abstracted into `DiscordCommandInteractionScriptEvent`.
  - ...with, unfortunately, some dubious abstractions due to JDA's design.
  - Instead of creating a language entry covering data from both events, they both have their own meta entries with lots of repetition. However, I believe this is preferable due to how event meta entries are formatted into sections.