### PR TITLE
`discordtimeout` command

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -62,6 +62,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             DenizenCore.commandRegistry.registerCommand(DiscordMessageCommand.class);
             DenizenCore.commandRegistry.registerCommand(DiscordModalCommand.class);
             DenizenCore.commandRegistry.registerCommand(DiscordReactCommand.class);
+            DenizenCore.commandRegistry.registerCommand(DiscordTimeoutCommand.class);
             // Events
             ScriptEvent.registerScriptEvent(DiscordApplicationCommandScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordButtonClickedScriptEvent.class);

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordBanCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordBanCommand.java
@@ -91,9 +91,7 @@ public class DiscordBanCommand extends AbstractCommand implements Holdable {
                         }
                         banAction.queue();
                     }
-                    case REMOVE -> {
-                        guild.unban(userObj).queue();
-                    }
+                    case REMOVE -> guild.unban(userObj).queue();
                 }
             }
             catch (Exception ex) {

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordBanCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordBanCommand.java
@@ -71,7 +71,7 @@ public class DiscordBanCommand extends AbstractCommand implements Holdable {
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgPrefixed @ArgName("id") DiscordBotTag bot,
-                                   @ArgName("instruction") DiscordBanInstruction instruction,
+                                   @ArgName("instruction") @ArgDefaultText("add") DiscordBanInstruction instruction,
                                    @ArgPrefixed @ArgName("user") DiscordUserTag user,
                                    @ArgPrefixed @ArgName("group") DiscordGroupTag group,
                                    @ArgPrefixed @ArgDefaultNull @ArgName("reason") String reason,
@@ -84,17 +84,15 @@ public class DiscordBanCommand extends AbstractCommand implements Holdable {
         Runnable runnable = () -> {
             try {
                 switch (instruction) {
-                    case ADD: {
+                    case ADD -> {
                         AuditableRestAction<Void> banAction = guild.ban(userObj, deletionTimeframe.getSecondsAsInt(), TimeUnit.SECONDS);
                         if (reason != null) {
                             banAction.reason(reason);
                         }
                         banAction.queue();
-                        break;
                     }
-                    case REMOVE: {
+                    case REMOVE -> {
                         guild.unban(userObj).queue();
-                        break;
                     }
                 }
             }

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
@@ -24,7 +24,7 @@ public class DiscordTimeoutCommand extends AbstractCommand implements Holdable {
 
     public DiscordTimeoutCommand() {
         setName("discordtimeout");
-        setSyntax("discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<time>)");
+        setSyntax("discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<duration>/{60s})");
         setRequiredArguments(3, 6);
         isProcedural = false;
         autoCompile();
@@ -32,7 +32,7 @@ public class DiscordTimeoutCommand extends AbstractCommand implements Holdable {
 
     // <--[command]
     // @Name discordtimeout
-    // @Syntax discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<time>/{60s})
+    // @Syntax discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<duration>/{60s})
     // @Required 3
     // @Maximum 6
     // @Short Puts a user in timeout.

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
@@ -35,13 +35,13 @@ public class DiscordTimeoutCommand extends AbstractCommand implements Holdable {
     // @Syntax discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<time>/{60s})
     // @Required 3
     // @Maximum 6
-    // @Short Put a user in timeout.
+    // @Short Puts a user in timeout.
     // @Plugin dDiscordBot
     // @Guide https://guide.denizenscript.com/guides/expanding/ddiscordbot.html
     // @Group external
     //
     // @Description
-    // Put a user in timeout.
+    // Puts a user in timeout.
     //
     // To put a user in timeout, use the "add" argument. To remove the timeout, use the "remove" argument.
     // The group is required for both "add" and "remove" arguments, but "reason" can only be used with "add".

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordTimeoutCommand.java
@@ -1,0 +1,110 @@
+package com.denizenscript.ddiscordbot.commands;
+
+import com.denizenscript.ddiscordbot.DenizenDiscordBot;
+import com.denizenscript.ddiscordbot.objects.DiscordBotTag;
+import com.denizenscript.ddiscordbot.objects.DiscordGroupTag;
+import com.denizenscript.ddiscordbot.objects.DiscordUserTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.Holdable;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultText;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import org.bukkit.Bukkit;
+
+import java.util.concurrent.TimeUnit;
+
+public class DiscordTimeoutCommand extends AbstractCommand implements Holdable {
+
+    public DiscordTimeoutCommand() {
+        setName("discordtimeout");
+        setSyntax("discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<time>)");
+        setRequiredArguments(3, 6);
+        isProcedural = false;
+        autoCompile();
+    }
+
+    // <--[command]
+    // @Name discordtimeout
+    // @Syntax discordtimeout [id:<id>] ({add}/remove) [user:<user>] [group:<group>] (reason:<reason>) (duration:<time>/{60s})
+    // @Required 3
+    // @Maximum 6
+    // @Short Put a user in timeout.
+    // @Plugin dDiscordBot
+    // @Guide https://guide.denizenscript.com/guides/expanding/ddiscordbot.html
+    // @Group external
+    //
+    // @Description
+    // Put a user in timeout.
+    //
+    // To put a user in timeout, use the "add" argument. To remove the timeout, use the "remove" argument.
+    // The group is required for both "add" and "remove" arguments, but "reason" can only be used with "add".
+    // Reasons show up in the group's Audit Logs.
+    //
+    // The timeout duration defaults to 60 seconds. The duration cannot be greater than 28 days.
+    // This argument can only be used when putting a user in timeout using the "add" argument, although it is not required.
+    //
+    // The command should usually be ~waited for. See <@link language ~waitable>.
+    //
+    // @Tags
+    // <DiscordUserTag.is_timed_out[<group>]> returns if the user is timed out in a certain group.
+    //
+    // @Usage
+    // # Put a user in timeout.
+    // - ~discordtimeout id:my_bot add user:<[user]> group:<[group]>
+    //
+    // @Usage
+    // # Put a user in timeout for a duration of 3 hours with a reason.
+    // - ~discordtimeout id:my_bot add user:<[user]> group:<[group]> "reason:Was being troublesome!" duration:3h
+    //
+    // @Usage
+    // # Remove a user from timeout.
+    // - ~discordtimeout id:my_bot remove user:<[user]> group:<[group]>
+    // -->
+
+    public enum DiscordTimeoutInstruction { ADD, REMOVE }
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("id") @ArgPrefixed DiscordBotTag bot,
+                                   @ArgName("instruction") @ArgDefaultText("add") DiscordTimeoutInstruction instruction,
+                                   @ArgName("user") @ArgPrefixed DiscordUserTag user,
+                                   @ArgName("group") @ArgPrefixed DiscordGroupTag group,
+                                   @ArgName("reason") @ArgPrefixed @ArgDefaultNull String reason,
+                                   @ArgName("duration") @ArgPrefixed @ArgDefaultText("60s") DurationTag duration) {
+        if (group.bot == null) {
+            group = new DiscordGroupTag(bot.bot, group.guild_id);
+        }
+        Guild guild = group.getGuild();
+        Member member = guild.getMemberById(user.user_id);
+        if (member == null) {
+            Debug.echoError("Invalid user! Are they in the Discord Group?");
+        }
+        Runnable runnable = () -> {
+            try {
+                switch (instruction) {
+                    case ADD -> {
+                        AuditableRestAction<Void> timeoutAction = member.timeoutFor(duration.getSecondsAsInt(), TimeUnit.SECONDS);
+                        if (reason != null) {
+                            timeoutAction.reason(reason);
+                        }
+                        timeoutAction.queue();
+                    }
+                    case REMOVE -> member.removeTimeout().queue();
+                }
+            }
+            catch (Exception ex) {
+                Debug.echoError(scriptEntry, ex);
+            }
+        };
+        Bukkit.getScheduler().runTaskAsynchronously(DenizenDiscordBot.instance, () -> {
+            runnable.run();
+            scriptEntry.setFinished(true);
+        });
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -444,6 +444,18 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
             }
             return new ElementTag(true);
         });
+
+        // <--[tag]
+        // @attribute <DiscordUserTag.is_timed_out[<group>]>
+        // @returns ElementTag(boolean)
+        // @plugin dDiscordBot
+        // @description
+        // Returns whether the user is timed out in a certain group.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, DiscordGroupTag.class, "is_timed_out", (attribute, object, group) -> {
+            Guild guild = group.getGuild();
+            return new ElementTag(guild.getMemberById(object.user_id).isTimedOut());
+        });
     }
 
     public static ObjectTagProcessor<DiscordUserTag> tagProcessor = new ObjectTagProcessor<>();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -454,7 +454,11 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // -->
         tagProcessor.registerTag(ElementTag.class, DiscordGroupTag.class, "is_timed_out", (attribute, object, group) -> {
             Guild guild = group.getGuild();
-            return new ElementTag(guild.getMemberById(object.user_id).isTimedOut());
+            Member member = guild.getMemberById(object.user_id);
+            if (member == null) {
+                Debug.echoError("Invalid user! Are they in the Discord Group?");
+            }
+            return new ElementTag(member.isTimedOut());
         });
     }
 


### PR DESCRIPTION
### `discordtimeout` command + `<DiscordUserTag.is_timed_out[<group>]>` tag

Also, provide a fix to `discordban` command: the meta docs said that the default action is `ADD`, but the code did not provide a default. Also upgraded to new java switch syntax :>

Suggested by Sudura on discord 😃 