### PR TITLE
channel `name` mechanism

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -578,12 +578,12 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
 
         // <--[mechanism]
         // @object DiscordChannelTag
-        // @name channel_name
+        // @name name
         // @input ElementTag
         // @description
-        // Renames this channel
+        // Renames this channel.
         // -->
-        if (mechanism.matches("channel_name")) {
+        if (mechanism.matches("name") && mechanism.requireObject(ElementTag.class)) {
             ((GuildChannel) getChannel()).getManager().setName(mechanism.getValue().asString()).submit();
         }
     }

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -575,5 +575,16 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         if (mechanism.matches("delete")) {
             getChannel().delete().complete();
         }
+
+        // <--[mechanism]
+        // @object DiscordChannelTag
+        // @name channel_name
+        // @input ElementTag
+        // @description
+        // Renames this channel
+        // -->
+        if (mechanism.matches("channel_name")) {
+            ((GuildChannel) getChannel()).getManager().setName(mechanism.getValue().asString()).submit();
+        }
     }
 }


### PR DESCRIPTION
## `channel_name` mechanism

For `DiscordChannelTag`s. Changes the name of a channel.

Requested by Hedwy on [Discord](https://discord.com/channels/315163488085475337/1082790105162461294)