### PR TITLE
DiscordChannelTag `topic` mech

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -529,19 +529,16 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // Does not work for thread or forum channels. Provide no input to reset the topic.
         // -->
         tagProcessor.registerMechanism("topic", false, (object, mechanism) -> {
-            if (mechanism.hasValue()) {
-                if (mechanism.requireObject(ElementTag.class)) {
-                    if (mechanism.getValue().asString().length() > 1024) {
-                        mechanism.echoError("Channel topic is too long! Channel topics can only be 1024 characters or fewer.");
-                        return;
-                    }
-                    // TODO: Add ability to change forum channel topics (guidelines)
-                    ((TextChannel) object.getChannel()).getManager().setTopic(mechanism.getValue().asString()).submit();
-                }
-            }
-            else {
+            if (!mechanism.hasValue()) {
                 ((TextChannel) object.getChannel()).getManager().setTopic(null).submit();
+                return;
             }
+            if (mechanism.getValue().asString().length() > 1024) {
+                mechanism.echoError("Channel topic is too long! Channel topics can only be 1024 characters or fewer.");
+                return;
+            }
+            // TODO: Add ability to change forum channel topics (guidelines)
+            ((TextChannel) object.getChannel()).getManager().setTopic(mechanism.getValue().asString()).submit();
         });
     }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -16,11 +16,11 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel;
 import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
 
 public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable {
@@ -428,6 +428,17 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
             return result;
         });
 
+        // <--[tag]
+        // @attribute <DiscordChannelTag.topic>
+        // @returns ElementTag
+        // @plugin dDiscordBot
+        // @description
+        // Returns the topic for this channel.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "topic", (attribute, object) -> {
+            return new ElementTag(((StandardGuildMessageChannel) object.getChannel()).getTopic());
+        });
+
         // <--[mechanism]
         // @object DiscordChannelTag
         // @name add_thread_member
@@ -530,15 +541,14 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // -->
         tagProcessor.registerMechanism("topic", false, (object, mechanism) -> {
             if (!mechanism.hasValue()) {
-                ((TextChannel) object.getChannel()).getManager().setTopic(null).submit();
+                ((StandardGuildMessageChannel) object.getChannel()).getManager().setTopic(null).submit();
                 return;
             }
             if (mechanism.getValue().asString().length() > 1024) {
                 mechanism.echoError("Channel topic is too long! Channel topics can only be 1024 characters or fewer.");
                 return;
             }
-            // TODO: Add ability to change forum channel topics (guidelines)
-            ((TextChannel) object.getChannel()).getManager().setTopic(mechanism.getValue().asString()).submit();
+            ((StandardGuildMessageChannel) object.getChannel()).getManager().setTopic(mechanism.getValue().asString()).submit();
         });
     }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -16,6 +16,7 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
@@ -517,6 +518,30 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // -->
         tagProcessor.registerMechanism("name", false, ElementTag.class, (object, mechanism, param) -> {
             ((GuildChannel) object.getChannel()).getManager().setName(param.asString()).submit();
+        });
+
+        // <--[mechanism]
+        // @object DiscordChannelTag
+        // @name topic
+        // @input ElementTag
+        // @description
+        // Changes the topic for this channel. The topic can only be 1024 characters or fewer.
+        // Does not work for thread or forum channels. Provide no input to reset the topic.
+        // -->
+        tagProcessor.registerMechanism("topic", false, (object, mechanism) -> {
+            if (mechanism.hasValue()) {
+                if (mechanism.requireObject(ElementTag.class)) {
+                    if (mechanism.getValue().asString().length() > 1024) {
+                        mechanism.echoError("Channel topic is too long! Channel topics can only be 1024 characters or fewer.");
+                        return;
+                    }
+                    // TODO: Add ability to change forum channel topics (guidelines)
+                    ((TextChannel) object.getChannel()).getManager().setTopic(mechanism.getValue().asString()).submit();
+                }
+            }
+            else {
+                ((TextChannel) object.getChannel()).getManager().setTopic(null).submit();
+            }
         });
     }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -432,6 +432,7 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // @attribute <DiscordChannelTag.topic>
         // @returns ElementTag
         // @plugin dDiscordBot
+        // @mechanism DiscordChannelTag.topic
         // @description
         // Returns the topic for this channel.
         // -->
@@ -538,6 +539,8 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // @description
         // Changes the topic for this channel. The topic can only be 1024 characters or fewer.
         // Does not work for thread or forum channels. Provide no input to reset the topic.
+        // @tags
+        // <DiscordChannelTag.topic>
         // -->
         tagProcessor.registerMechanism("topic", false, (object, mechanism) -> {
             if (!mechanism.hasValue()) {


### PR DESCRIPTION
### `topic` mech

For `DiscordChannelTag`s.

Sets the topic of a channel. To reset it, give no input. Also, the topics cannot be greater than 1024 characters.

#### TODO
Forum channel topics (guidelines) are a bit more obscure and I haven't found a good way to do it yet, so that is going to be a TODO for now. :/

Requested by DCaff95 on [Discord](https://discord.com/channels/315163488085475337/1084935192352936056/1084935192352936056)