### PR TITLE
Version bump + two new tags.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.4</version>
+            <version>5.0.0-beta.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
@@ -3,7 +3,6 @@ package com.denizenscript.ddiscordbot.objects;
 import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.ddiscordbot.DenizenDiscordBot;
 import com.denizenscript.denizencore.objects.core.ColorTag;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
@@ -18,8 +17,6 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
-import net.dv8tion.jda.api.managers.RoleManager;
 
 import java.awt.Color;
 import java.util.List;

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
@@ -3,6 +3,7 @@ package com.denizenscript.ddiscordbot.objects;
 import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.ddiscordbot.DenizenDiscordBot;
 import com.denizenscript.denizencore.objects.core.ColorTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
@@ -17,6 +18,8 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.managers.RoleManager;
 
 import java.awt.Color;
 import java.util.List;
@@ -252,6 +255,30 @@ public class DiscordRoleTag implements ObjectTag, FlaggableObject, Adjustable {
                 list.addObject(new ElementTag(perm));
             }
             return list;
+        });
+
+        // <--[mechanism]
+        // @object DiscordRoleTag
+        // @name color
+        // @input ColorTag
+        // @description
+        // Adjusts the specified role's color to the given <@link objecttype ColorTag>.
+        // -->
+        tagProcessor.registerMechanism("color", false, ColorTag.class, (object, mechanism, color) -> {
+            object.role.getManager().setColor(color.asRGB()).queue();
+        });
+
+        // <--[mechanism]
+        // @object DiscordRoleTag
+        // @name mentionable
+        // @input ElementTag(Boolean)
+        // @description
+        // Adjusts the specified role's mentionable status.
+        // -->
+        tagProcessor.registerMechanism("mentionable", false, ElementTag.class, (object, mechanism, input) -> {
+            if (mechanism.requireBoolean()) {
+                object.role.getManager().setMentionable(input.asBoolean()).queue();
+            }
         });
     }
 


### PR DESCRIPTION
# Additions
- Adds the ``color`` mechanism for the ``DiscordRoleTag`` object, allowing for the adjustment of the color of a Discord role.
- Adds the ``mentionable`` mechanism for the ``DiscordRoleTag`` object, allowing for the adjustment of the mention option of a Discord role.

# Updates
- Bumped JDA version from ``5.0.0-beta.4`` --> ``5.0.0-beta.12``.