### PR TITLE
Boosts Events and Tags

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -68,6 +68,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordChannelCreateScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordChannelDeleteScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordCommandAutocompleteScriptEvent.class);
+            ScriptEvent.registerScriptEvent(DiscordInviteCreateScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageDeletedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageModifiedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordMessageReactionAddScriptEvent.class);
@@ -81,7 +82,6 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordUserLeavesScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserNicknameChangeScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserRoleChangeScriptEvent.class);
-            ScriptEvent.registerScriptEvent(DiscordInviteCreateScriptEvent.class);
             // Objects
             ObjectFetcher.registerWithObjectFetcher(DiscordBotTag.class, DiscordBotTag.tagProcessor);
             ObjectFetcher.registerWithObjectFetcher(DiscordButtonTag.class, DiscordButtonTag.tagProcessor);

--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -81,6 +81,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordUserLeavesScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserNicknameChangeScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserRoleChangeScriptEvent.class);
+            ScriptEvent.registerScriptEvent(DiscordInviteCreateScriptEvent.class);
             // Objects
             ObjectFetcher.registerWithObjectFetcher(DiscordBotTag.class, DiscordBotTag.tagProcessor);
             ObjectFetcher.registerWithObjectFetcher(DiscordButtonTag.class, DiscordButtonTag.tagProcessor);

--- a/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DenizenDiscordBot.java
@@ -77,6 +77,7 @@ public class DenizenDiscordBot extends JavaPlugin {
             ScriptEvent.registerScriptEvent(DiscordSelectionUsedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordThreadArchivedScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordThreadRevealedScriptEvent.class);
+            ScriptEvent.registerScriptEvent(DiscordUpdateBoostCountEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserJoinsScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserLeavesScriptEvent.class);
             ScriptEvent.registerScriptEvent(DiscordUserNicknameChangeScriptEvent.class);

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -117,11 +117,6 @@ public class DiscordConnection extends ListenerAdapter {
     }
 
     @Override
-    public void onGuildUpdateBoostCount(GuildUpdateBoostCountEvent event) {
-        autoHandle(event, DiscordUpdateBoostCountEvent.instance);
-    }
-
-    @Override
     public void onGuildMemberRoleAdd(GuildMemberRoleAddEvent event) {
         autoHandle(event, DiscordUserRoleChangeScriptEvent.instance);
     }
@@ -136,6 +131,11 @@ public class DiscordConnection extends ListenerAdapter {
         autoHandle(event, DiscordUserNicknameChangeScriptEvent.instance);
     }
 
+    @Override
+    public void onGuildUpdateBoostCount(GuildUpdateBoostCountEvent event) {
+        autoHandle(event, DiscordUpdateBoostCountEvent.instance);
+    }
+    
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         autoHandle(event, DiscordApplicationCommandScriptEvent.instance);

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -135,7 +135,7 @@ public class DiscordConnection extends ListenerAdapter {
     public void onGuildUpdateBoostCount(GuildUpdateBoostCountEvent event) {
         autoHandle(event, DiscordUpdateBoostCountEvent.instance);
     }
-    
+
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         autoHandle(event, DiscordApplicationCommandScriptEvent.instance);

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
+import net.dv8tion.jda.api.events.guild.update.GuildUpdateBoostCountEvent;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
@@ -113,6 +114,11 @@ public class DiscordConnection extends ListenerAdapter {
     @Override
     public void onGuildMemberRemove(GuildMemberRemoveEvent event) {
         autoHandle(event, DiscordUserLeavesScriptEvent.instance);
+    }
+
+    @Override
+    public void onGuildUpdateBoostCount(GuildUpdateBoostCountEvent event) {
+        autoHandle(event, DiscordUpdateBoostCountEvent.instance);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/DiscordConnection.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.events.channel.ChannelDeleteEvent;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
@@ -163,6 +164,11 @@ public class DiscordConnection extends ListenerAdapter {
     @Override
     public void onGenericSelectMenuInteraction(GenericSelectMenuInteractionEvent event) {
         autoHandle(event, DiscordSelectionUsedScriptEvent.instance);
+    }
+
+    @Override
+    public void onGuildInviteCreate(GuildInviteCreateEvent event) {
+        autoHandle(event, DiscordInviteCreateScriptEvent.instance);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -46,6 +46,9 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
 
     @Override
     public boolean matches(ScriptPath path) {
+        if (!tryChannel(path, getEvent().getChannel())) {
+            return false;
+        }
         if (!tryGuild(path, getEvent().getGuild())) {
             return false;
         }

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -26,8 +26,8 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
     //
     // @Context
     // <context.bot> returns the relevant DiscordBotTag.
-    // <context.group> returns the DiscordGroupTag.
-    // <context.channel> returns the DiscordChannelTag.
+    // <context.group> returns the DiscordGroupTag of the created invitation.
+    // <context.channel> returns the DiscordChannelTag of the created invitation.
     // <context.user> returns the DiscordUserTag of the invitation creator.
     // <context.code> returns the invitation code (after the last "/" in the URL).
     // <context.url> returns the invitation URL.

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -1,0 +1,72 @@
+package com.denizenscript.ddiscordbot.events;
+
+import com.denizenscript.ddiscordbot.DiscordScriptEvent;
+import com.denizenscript.ddiscordbot.objects.DiscordChannelTag;
+import com.denizenscript.ddiscordbot.objects.DiscordGroupTag;
+import com.denizenscript.ddiscordbot.objects.DiscordUserTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
+
+public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
+
+    // <--[event]
+    // @Events
+    // discord invitation created
+    //
+    // @Switch for:<bot> to only process the event for a specified Discord bot.
+    // @Switch group:<group_id> to only process the event for a specified Discord group.
+    //
+    // @Triggers when a Discord user creates an invitation.
+    //
+    // @Plugin dDiscordBot
+    //
+    // @Group Discord
+    //
+    // @Context
+    // <context.bot> returns the relevant DiscordBotTag.
+    // <context.group> returns the DiscordGroupTag.
+    // <context.channel> returns the DiscordChannelTag.
+    // <context.user> returns the DiscordUserTag of the invitation creator.
+    // <context.code> returns the ElementTag of the invitation code (after the "/" in the URL.
+    // <context.url> returns the ElementTag of the invitation URL
+    // -->
+
+    public static DiscordInviteCreateScriptEvent instance;
+
+    public DiscordInviteCreateScriptEvent() {
+        instance = this;
+        registerCouldMatcher("discord invitation created");
+        registerSwitches("channel", "group");
+    }
+
+    public GuildInviteCreateEvent getEvent() {
+        return (GuildInviteCreateEvent) event;
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!tryGuild(path, getEvent().getGuild())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "channel":
+                return new DiscordChannelTag(botID, getEvent().getChannel());
+            case "group":
+                return new DiscordGroupTag(botID, getEvent().getGuild());
+            case "user":
+                return new DiscordUserTag(botID, getEvent().getInvite().getInviter());
+            case "code":
+                return new ElementTag(getEvent().getInvite().getCode());
+            case "url":
+                return new ElementTag(getEvent().getInvite().getUrl());
+        }
+        return super.getContext(name);
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -29,7 +29,7 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
     // <context.group> returns the DiscordGroupTag.
     // <context.channel> returns the DiscordChannelTag.
     // <context.user> returns the DiscordUserTag of the invitation creator.
-    // <context.code> returns the invitation code (after the latest "/" in the URL).
+    // <context.code> returns the invitation code (after the last "/" in the URL).
     // <context.url> returns the invitation URL.
     // -->
 

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -7,7 +7,6 @@ import com.denizenscript.ddiscordbot.objects.DiscordUserTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 
 public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
 

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -15,6 +15,7 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
     // discord invitation created
     //
     // @Switch for:<bot> to only process the event for a specified Discord bot.
+    // @Switch channel:<channel_id> to only process the event for a specified Discord channel.
     // @Switch group:<group_id> to only process the event for a specified Discord group.
     //
     // @Triggers when a Discord user creates an invitation.
@@ -28,8 +29,8 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
     // <context.group> returns the DiscordGroupTag.
     // <context.channel> returns the DiscordChannelTag.
     // <context.user> returns the DiscordUserTag of the invitation creator.
-    // <context.code> returns the ElementTag of the invitation code (after the "/" in the URL.
-    // <context.url> returns the ElementTag of the invitation URL
+    // <context.code> returns the invitation code (after the latest "/" in the URL).
+    // <context.url> returns the invitation URL.
     // -->
 
     public static DiscordInviteCreateScriptEvent instance;
@@ -57,19 +58,14 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "channel":
-                return new DiscordChannelTag(botID, getEvent().getChannel());
-            case "group":
-                return new DiscordGroupTag(botID, getEvent().getGuild());
-            case "user":
-                return new DiscordUserTag(botID, getEvent().getInvite().getInviter());
-            case "code":
-                return new ElementTag(getEvent().getInvite().getCode());
-            case "url":
-                return new ElementTag(getEvent().getInvite().getUrl());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "channel" -> new DiscordChannelTag(botID, getEvent().getChannel());
+            case "group" -> new DiscordGroupTag(botID, getEvent().getGuild());
+            case "user" -> new DiscordUserTag(botID, getEvent().getInvite().getInviter());
+            case "code" -> new ElementTag(getEvent().getInvite().getCode(), true);
+            case "url" -> new ElementTag(getEvent().getInvite().getUrl(), true);
+            default -> super.getContext(name);
+        };
     }
 }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordInviteCreateScriptEvent.java
@@ -70,3 +70,4 @@ public class DiscordInviteCreateScriptEvent extends DiscordScriptEvent {
         return super.getContext(name);
     }
 }
+

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
@@ -23,9 +23,9 @@ public class DiscordUpdateBoostCountEvent extends DiscordScriptEvent {
     //
     // @Context
     // <context.bot> returns the relevant DiscordBotTag.
-    // <context.group> returns the DiscordGroupTag.
-    // <context.new_count> returns the new amount of boosts of the group.
-    // <context.old_count> returns the old amount of boosts of the group.
+    // <context.group> returns the DiscordGroupTag whose boost count changed.
+    // <context.new_count> returns the group's new new amount of boosts.
+    // <context.old_count> returns the group's old amount of boosts.
     // -->
 
     public static DiscordUpdateBoostCountEvent instance;
@@ -51,6 +51,7 @@ public class DiscordUpdateBoostCountEvent extends DiscordScriptEvent {
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
+            case "group" -> new DiscordGroupTag(botID, getEvent().getGuild());
             case "new_count" -> new DiscordGroupTag(botID, getEvent().getNewBoostCount());
             case "old_count" -> new DiscordGroupTag(botID, getEvent().getOldBoostCount());
             default -> super.getContext(name);

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
@@ -52,7 +52,7 @@ public class DiscordUpdateBoostCountEvent extends DiscordScriptEvent {
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "new_count" -> new DiscordGroupTag(botID, getEvent().getNewBoostCount());
-            case "old_count" -> new DiscordUserTag(botID, getEvent().getOldBoostCount());
+            case "old_count" -> new DiscordGroupTag(botID, getEvent().getOldBoostCount());
             default -> super.getContext(name);
         };
     }

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
@@ -1,0 +1,59 @@
+package com.denizenscript.ddiscordbot.events;
+
+import com.denizenscript.ddiscordbot.DiscordScriptEvent;
+import com.denizenscript.ddiscordbot.objects.DiscordGroupTag;
+import com.denizenscript.ddiscordbot.objects.DiscordUserTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import net.dv8tion.jda.api.events.guild.update.GuildUpdateBoostCountEvent;
+
+public class DiscordUpdateBoostCountEvent extends DiscordScriptEvent {
+
+    // <--[event]
+    // @Events
+    // discord boosts count changes
+    //
+    // @Switch for:<bot> to only process the event for a specified Discord bot.
+    // @Switch group:<group_id> to only process the event for a specified Discord group.
+    //
+    // @Triggers when the boosts count of the server changes
+    //
+    // @Plugin dDiscordBot
+    //
+    // @Group Discord
+    //
+    // @Context
+    // <context.bot> returns the relevant DiscordBotTag.
+    // <context.group> returns the DiscordGroupTag.
+    // <context.new_count> returns the new count of the group's boosts.
+    // <context.old_count> returns the old count of the group's boosts.
+    // -->
+
+    public static DiscordUpdateBoostCountEvent instance;
+
+    public DiscordUpdateBoostCountEvent() {
+        instance = this;
+        registerCouldMatcher("discord boosts count changes");
+        registerSwitches("group");
+    }
+
+    public GuildUpdateBoostCountEvent getEvent() {
+        return (GuildUpdateBoostCountEvent) event;
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!tryGuild(path, getEvent().getGuild())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "new_count" -> new DiscordGroupTag(botID, getEvent().getNewBoostCount());
+            case "old_count" -> new DiscordUserTag(botID, getEvent().getOldBoostCount());
+            default -> super.getContext(name);
+        };
+    }
+}

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordUpdateBoostCountEvent.java
@@ -24,8 +24,8 @@ public class DiscordUpdateBoostCountEvent extends DiscordScriptEvent {
     // @Context
     // <context.bot> returns the relevant DiscordBotTag.
     // <context.group> returns the DiscordGroupTag.
-    // <context.new_count> returns the new count of the group's boosts.
-    // <context.old_count> returns the old count of the group's boosts.
+    // <context.new_count> returns the new amount of boosts of the group.
+    // <context.old_count> returns the old amount of boosts of the group.
     // -->
 
     public static DiscordUpdateBoostCountEvent instance;

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -190,6 +190,43 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         });
 
         // <--[tag]
+        // @attribute <DiscordGroupTag.boosters>
+        // @returns ListTag(DiscordUserTag)
+        // @plugin dDiscordBot
+        // @description
+        // Returns a list of all users in the group that currently boosts the server.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "boosters", (attribute, object) -> {
+            ListTag list = new ListTag();
+            for (Member member : object.getGuild().getBoosters()) {
+                list.addObject(new DiscordUserTag(object.bot, member.getUser()));
+            }
+            return list;
+        });
+
+        // <--[tag]
+        // @attribute <DiscordGroupTag.boosts_count>
+        // @returns ElementTag(Number)
+        // @plugin dDiscordBot
+        // @description
+        // Returns the amount of boosts the group currently has.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "boosts_count", (attribute, object) -> {
+            return new ElementTag(object.getGuild().getBoostCount());
+        });
+
+        // <--[tag]
+        // @attribute <DiscordGroupTag.tier>
+        // @returns ElementTag(Number)
+        // @plugin dDiscordBot
+        // @description
+        // Returns the tier (0 to 3) of the group currently set by its boosts.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "tier", (attribute, object) -> {
+            return new ElementTag(object.getGuild().getBoostTier());
+        });
+
+        // <--[tag]
         // @attribute <DiscordGroupTag.banned_members>
         // @returns ListTag(DiscordUserTag)
         // @plugin dDiscordBot

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -217,7 +217,7 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ElementTag
         // @plugin dDiscordBot
         // @description
-        // Returns the tier of the group currently set by its boosts.
+        // Returns the current tier of the group set by its boosts.
         // You can get a list of possible outputs here: <@link url https://docs.jda.wiki/net/dv8tion/jda/api/entities/Guild.BoostTier.html>
         // -->
         tagProcessor.registerTag(ElementTag.class, "boost_tier", (attribute, object) -> {

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -194,14 +194,11 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ListTag(DiscordUserTag)
         // @plugin dDiscordBot
         // @description
-        // Returns a list of all users in the group that currently boosts the group.
+        // Returns a list of all users in the group that currently boosts it.
         // -->
         tagProcessor.registerTag(ListTag.class, "boosters", (attribute, object) -> {
-            ListTag list = new ListTag();
-            for (Member member : object.getGuild().getBoosters()) {
-                list.addObject(new DiscordUserTag(object.bot, member.getUser()));
-            }
-            return list;
+            List<Member> boosters = object.getGuild().getBoosters();
+            return new ListTag(boosters, member -> new DiscordUserTag(object.bot, member.getUser()));
         });
 
         // <--[tag]
@@ -216,14 +213,14 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         });
 
         // <--[tag]
-        // @attribute <DiscordGroupTag.tier>
-        // @returns ElementTag(Number)
+        // @attribute <DiscordGroupTag.boost_tier>
+        // @returns ElementTag
         // @plugin dDiscordBot
         // @description
         // Returns the tier of the group currently set by its boosts.
         // You can get a list of possible outputs here: <@link url https://docs.jda.wiki/net/dv8tion/jda/api/entities/Guild.BoostTier.html>
         // -->
-        tagProcessor.registerTag(ElementTag.class, "tier", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "boost_tier", (attribute, object) -> {
             return new ElementTag(object.getGuild().getBoostTier());
         });
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -194,7 +194,7 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ListTag(DiscordUserTag)
         // @plugin dDiscordBot
         // @description
-        // Returns a list of all users in the group that currently boosts the server.
+        // Returns a list of all users in the group that currently boosts the group.
         // -->
         tagProcessor.registerTag(ListTag.class, "boosters", (attribute, object) -> {
             ListTag list = new ListTag();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordGroupTag.java
@@ -220,7 +220,8 @@ public class DiscordGroupTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ElementTag(Number)
         // @plugin dDiscordBot
         // @description
-        // Returns the tier (0 to 3) of the group currently set by its boosts.
+        // Returns the tier of the group currently set by its boosts.
+        // You can get a list of possible outputs here: <@link url https://docs.jda.wiki/net/dv8tion/jda/api/entities/Guild.BoostTier.html>
         // -->
         tagProcessor.registerTag(ElementTag.class, "tier", (attribute, object) -> {
             return new ElementTag(object.getGuild().getBoostTier());

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
@@ -245,7 +245,7 @@ public class DiscordRoleTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ListTag
         // @plugin dDiscordBot
         // @description
-        // Returns a list of permissions that the role provides for users. You can get a list of possible outputs here: <@link url https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html>
+        // Returns a list of permissions that the role provides for users. You can get a list of possible outputs here: <@link url https://docs.jda.wiki/net/dv8tion/jda/api/Permission.html>
         // -->
         tagProcessor.registerTag(ListTag.class, "permissions", (attribute, object) -> {
             ListTag list = new ListTag();

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -245,7 +245,7 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ElementTag(Boolean)
         // @plugin dDiscordBot
         // @description
-        // Returns a boolean indicating whether the user is boosting the specified server or not.
+        // Returns a boolean indicating whether the user is boosting the specified group or not.
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_boosting", (attribute, object) -> {
             if (!attribute.hasParam()) {

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -241,6 +241,31 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         });
 
         // <--[tag]
+        // @attribute <DiscordUserTag.is_boosting[<group>]>
+        // @returns ElementTag(Boolean)
+        // @plugin dDiscordBot
+        // @description
+        // Returns a boolean indicating whether the user is boosting the specified server or not.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "is_boosting", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                return null;
+            }
+            DiscordGroupTag group = attribute.paramAsType(DiscordGroupTag.class);
+            if (group == null) {
+                return null;
+            }
+            if (object.getUserForTag(attribute) == null) {
+                return null;
+            }
+            Member member = group.getGuild().getMember(object.getUser());
+            if (member == null) {
+                return null;
+            }
+            return new ElementTag(member.isBoosting());
+        });
+
+        // <--[tag]
         // @attribute <DiscordUserTag.avatar_url>
         // @returns ElementTag
         // @plugin dDiscordBot

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -247,21 +247,11 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // @description
         // Returns a boolean indicating whether the user is boosting the specified group or not.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "is_boosting", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
-            DiscordGroupTag group = attribute.paramAsType(DiscordGroupTag.class);
-            if (group == null) {
-                return null;
-            }
-            if (object.getUserForTag(attribute) == null) {
-                return null;
+        tagProcessor.registerTag(ElementTag.class, DiscordGroupTag.class, "is_boosting", (attribute, object, group) -> {
+            if (object.getUser() == null) {
+                return new ElementTag(false);
             }
             Member member = group.getGuild().getMember(object.getUser());
-            if (member == null) {
-                return null;
-            }
             return new ElementTag(member.isBoosting());
         });
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -482,7 +482,7 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ListTag
         // @plugin dDiscordBot
         // @description
-        // Returns a list of permissions that the user has in a certain group. You can get a list of possible outputs here: <@link url https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html>
+        // Returns a list of permissions that the user has in a certain group. You can get a list of possible outputs here: <@link url https://docs.jda.wiki/net/dv8tion/jda/api/Permission.html>
         // -->
         tagProcessor.registerTag(ListTag.class, "permissions", (attribute, object) -> {
             if (!attribute.hasParam()) {

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordUserTag.java
@@ -231,7 +231,7 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ElementTag(Boolean)
         // @plugin dDiscordBot
         // @description
-        // Returns a boolean indicating whether the user is a bot.
+        // Returns whether the user is a bot or not.
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_bot", (attribute, object) -> {
             if (object.getUserForTag(attribute) == null) {
@@ -245,10 +245,10 @@ public class DiscordUserTag implements ObjectTag, FlaggableObject, Adjustable {
         // @returns ElementTag(Boolean)
         // @plugin dDiscordBot
         // @description
-        // Returns a boolean indicating whether the user is boosting the specified group or not.
+        // Return whether the user is boosting the specified group or not.
         // -->
         tagProcessor.registerTag(ElementTag.class, DiscordGroupTag.class, "is_boosting", (attribute, object, group) -> {
-            if (object.getUser() == null) {
+            if (object.getUserForTag(attribute) == null) {
                 return new ElementTag(false);
             }
             Member member = group.getGuild().getMember(object.getUser());


### PR DESCRIPTION
Adding 4 tags and 1 new event to support discord boosts integration.

**New Tags**
 * `DiscordUserTag.is_boosting[<group>]`
 * `DiscordGroupTag.boosters`
 * `DiscordGroupTag.boost_tier`
 * `DiscordGroupTag.boosts_count`
 
**New Events**
 * `discord boosts count changes`

Updating the java docs link to the new one.

