### PR TITLE
JDA 6.4.1 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <BUILD_NUMBER>Unknown</BUILD_NUMBER>
-        <bukkit.version>26.1-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>26.1.1-R0.1-SNAPSHOT</bukkit.version>
         <denizen.version>1.3.2-SNAPSHOT</denizen.version>
     </properties>
 
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.12</version> <!-- TODO: THIS IS VERY OLD, BUT THERE WERE BREAKING CHANGES -->
+            <version>6.4.1</version>
         </dependency>
     </dependencies>
 
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordConnectCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordConnectCommand.java
@@ -19,7 +19,6 @@ import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -29,10 +28,8 @@ import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.bukkit.Bukkit;
-import org.slf4j.Logger;
 
 import java.io.*;
-import java.lang.invoke.MethodHandle;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -107,22 +104,11 @@ public class DiscordConnectCommand extends AbstractCommand implements Holdable {
         // Dirty hack step 1: break System.err so Paper won't complain when JDALogger's static init whines into System.err
         PrintStream currentErr = System.err;
         System.setErr(altLogger);
-        Logger defaultLogger = null;
         try {
-            // Force JDALogger to init now, which will do that spam, and get a SimpleLogger instance while we're at it.
-            defaultLogger = JDALogger.getLog(DiscordConnectCommand.class);
+            JDALogger.getLog(DiscordConnectCommand.class);
         }
         finally {
-            // Fix the logger back, with a try/finally to avoid breaking it.
             System.setErr(currentErr);
-        }
-        try {
-            // Dirty hack step 2: use that SimpleLogger instance to modify the class and redirect its log path to one that won't get complained about by Paper.
-            MethodHandle streamSetter = ReflectionHelper.getFinalSetter(defaultLogger.getClass(), "TARGET_STREAM");
-            streamSetter.invoke(altLogger);
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
         }
     }
 
@@ -130,7 +116,7 @@ public class DiscordConnectCommand extends AbstractCommand implements Holdable {
         fixJDALogger();
     }
 
-    public static HashSet<GatewayIntent> defaultIntents = new HashSet<>(Arrays.asList(GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_EMOJIS_AND_STICKERS, GatewayIntent.GUILD_MESSAGE_REACTIONS,
+    public static HashSet<GatewayIntent> defaultIntents = new HashSet<>(Arrays.asList(GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_EXPRESSIONS, GatewayIntent.GUILD_MESSAGE_REACTIONS,
             GatewayIntent.GUILD_MESSAGES, GatewayIntent.DIRECT_MESSAGE_REACTIONS, GatewayIntent.DIRECT_MESSAGES, GatewayIntent.MESSAGE_CONTENT));
 
     public static void runConnect(String code, DiscordConnection conn, ScriptEntry scriptEntry, HashSet<GatewayIntent> intents) {

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordMessageCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordMessageCommand.java
@@ -16,13 +16,13 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumPost;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.ItemComponent;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.*;
 
@@ -136,7 +136,7 @@ public class DiscordMessageCommand extends AbstractCommand implements Holdable {
         Collection<ObjectTag> rows = CoreUtilities.objectToList(rowsObj, scriptEntry.getContext());
         List<ActionRow> actionRows = new ArrayList<>();
         for (ObjectTag row : rows) {
-            List<ItemComponent> components = new ArrayList<>();
+            List<ActionRowChildComponent> components = new ArrayList<>();
             for (ObjectTag component : CoreUtilities.objectToList(row, scriptEntry.getContext())) {
                 if (component.canBeType(DiscordButtonTag.class)) {
                     components.add(component.asType(DiscordButtonTag.class, scriptEntry.getContext()).build());

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordModalCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordModalCommand.java
@@ -12,14 +12,12 @@ import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.dv8tion.jda.api.components.label.Label;
 import net.dv8tion.jda.api.interactions.callbacks.IModalCallback;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.ItemComponent;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 public class DiscordModalCommand extends AbstractCommand implements Holdable {
 
@@ -77,36 +75,36 @@ public class DiscordModalCommand extends AbstractCommand implements Holdable {
         if (interaction.interaction == null) {
             throw new InvalidArgumentsRuntimeException("Invalid interaction! Has it expired?");
         }
-        List<ActionRow> actionRows = createRows(scriptEntry, rows);
-        if (actionRows == null || actionRows.isEmpty()) {
+        Collection<Label> modalRows = createRows(scriptEntry, rows);
+        if (modalRows == null || modalRows.isEmpty()) {
             throw new InvalidArgumentsRuntimeException("Invalid action rows!");
         }
         if (interaction.interaction.isAcknowledged()) {
             throw new InvalidArgumentsRuntimeException("Interaction already acknowledged!");
         }
         IModalCallback replyTo = (IModalCallback) interaction.interaction;
-        Modal modal = Modal.create(name, title).addActionRows(actionRows).build();
+        Modal modal = Modal.create(name, title).addComponents(modalRows).build();
         DiscordCommandUtils.cleanWait(scriptEntry, replyTo.replyModal(modal));
     }
 
-    public static List<ActionRow> createRows(ScriptEntry scriptEntry, ObjectTag rowsObj) {
+    public static Collection<Label> createRows(ScriptEntry scriptEntry, ObjectTag rowsObj) {
         if (rowsObj == null) {
             return null;
         }
         Collection<ObjectTag> rows = CoreUtilities.objectToList(rowsObj, scriptEntry.getContext());
-        List<ActionRow> actionRows = new ArrayList<>();
+        Collection<Label> modalRows = new ArrayList<>();
         for (ObjectTag row : rows) {
-            List<ItemComponent> components = new ArrayList<>();
             for (ObjectTag component : CoreUtilities.objectToList(row, scriptEntry.getContext())) {
                 if (component.canBeType(DiscordTextInputTag.class)) {
-                    components.add(component.asType(DiscordTextInputTag.class, scriptEntry.getContext()).build());
+                    DiscordTextInputTag textInput = component.asType(DiscordTextInputTag.class, scriptEntry.getContext());
+                    Label label = Label.of(textInput.textInputData.getElement("label").asString(), textInput.build());
+                    modalRows.add(label);
                 }
                 else {
                     Debug.echoError("Unsupported modal component list entry '" + component + "'");
                 }
             }
-            actionRows.add(ActionRow.of(components));
         }
-        return actionRows;
+        return modalRows;
     }
 }

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordButtonClickedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordButtonClickedScriptEvent.java
@@ -52,7 +52,7 @@ public class DiscordButtonClickedScriptEvent extends DiscordScriptEvent {
         if (!tryGuild(path, getEvent().isFromGuild() ? getEvent().getGuild() : null)) {
             return false;
         }
-        if (!runGenericSwitchCheck(path, "id", getEvent().getButton().getId())) {
+        if (!runGenericSwitchCheck(path, "id", getEvent().getButton().getCustomId())) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordModalSubmittedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordModalSubmittedScriptEvent.java
@@ -82,7 +82,7 @@ public class DiscordModalSubmittedScriptEvent extends DiscordScriptEvent {
                 return new ElementTag(getEvent().getModalId());
             case "values":
                 Map<StringHolder, ObjectTag> map = getEvent().getValues().stream()
-                        .collect(Collectors.toMap(key -> new StringHolder(key.getId()), value -> new ElementTag(value.getAsString(), true)));
+                        .collect(Collectors.toMap(key -> new StringHolder(key.getCustomId()), value -> new ElementTag(value.getAsString(), true)));
                 return new MapTag(map);
         }
         return super.getContext(name);

--- a/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/events/DiscordSelectionUsedScriptEvent.java
@@ -54,7 +54,7 @@ public class DiscordSelectionUsedScriptEvent extends DiscordScriptEvent {
         if (!tryGuild(path, getEvent().isFromGuild() ? getEvent().getGuild() : null)) {
             return false;
         }
-        if (!runGenericSwitchCheck(path, "id", getEvent().getSelectMenu().getId())) {
+        if (!runGenericSwitchCheck(path, "id", getEvent().getSelectMenu().getCustomId())) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordButtonTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordButtonTag.java
@@ -9,9 +9,9 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -69,8 +69,8 @@ public class DiscordButtonTag implements ObjectTag {
         buttonData.putObject("style", new ElementTag(button.getStyle()));
         buttonData.putObject("label", new ElementTag(button.getLabel()));
         buttonData.putObject("disabled", new ElementTag(button.isDisabled()));
-        if (button.getId() != null) {
-            buttonData.putObject("id", new ElementTag(button.getId()));
+        if (button.getCustomId() != null) {
+            buttonData.putObject("id", new ElementTag(button.getCustomId()));
         }
         if (button.getEmoji() != null) {
             buttonData.putObject("emoji", new ElementTag(button.getEmoji().getName()));

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordChannelTag.java
@@ -2,7 +2,6 @@ package com.denizenscript.ddiscordbot.objects;
 
 import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.ddiscordbot.DenizenDiscordBot;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.RedirectionFlagTracker;
@@ -13,14 +12,12 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.*;
 import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
 
 public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable {
@@ -361,15 +358,11 @@ public class DiscordChannelTag implements ObjectTag, FlaggableObject, Adjustable
         // Returns a list of the messages that are pinned in the channel.
         // -->
         tagProcessor.registerTag(ListTag.class, "pinned_messages", (attribute, object) -> {
-            ListTag list = new ListTag();
             MessageChannel channel = (MessageChannel) object.getChannel();
             if (channel == null) {
                 return null;
             }
-            for (Message message : channel.retrievePinnedMessages().complete()) {
-                list.addObject(new DiscordMessageTag(object.bot, message));
-            }
-            return list;
+            return new ListTag(channel.retrievePinnedMessages().complete(), message -> new DiscordMessageTag(object.bot, message.getMessage()));
         });
 
         // <--[tag]

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordRoleTag.java
@@ -2,21 +2,21 @@ package com.denizenscript.ddiscordbot.objects;
 
 import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.ddiscordbot.DenizenDiscordBot;
-import com.denizenscript.denizencore.objects.core.ColorTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.RedirectionFlagTracker;
 import com.denizenscript.denizencore.objects.*;
+import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.Permission;
 
 import java.awt.Color;
 import java.util.List;
@@ -218,7 +218,7 @@ public class DiscordRoleTag implements ObjectTag, FlaggableObject, Adjustable {
         // Returns the display color of the role, if any.
         // -->
         tagProcessor.registerTag(ColorTag.class, "color", (attribute, object) -> {
-            Color color = object.role.getColor();
+            Color color = object.role.getColors().getPrimary();
             if (color == null) {
                 return null;
             }

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordSelectionTag.java
@@ -10,10 +10,10 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
+import net.dv8tion.jda.api.components.selections.SelectMenu;
+import net.dv8tion.jda.api.components.selections.SelectOption;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
-import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
-import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -85,9 +85,7 @@ public class DiscordSelectionTag implements ObjectTag {
             throw new UnsupportedOperationException();
         }
         menuData = new MapTag();
-        if (menu.getId() != null) {
-            menuData.putObject("id", new ElementTag(menu.getId()));
-        }
+        menuData.putObject("id", new ElementTag(menu.getCustomId()));
         if (menu.getPlaceholder() != null) {
             menuData.putObject("placeholder", new ElementTag(menu.getPlaceholder()));
         }

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordTextInputTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordTextInputTag.java
@@ -9,8 +9,8 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.components.textinput.TextInput;
+import net.dv8tion.jda.api.components.textinput.TextInputStyle;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,8 +66,7 @@ public class DiscordTextInputTag implements ObjectTag {
     public DiscordTextInputTag(TextInput textInput) {
         textInputData = new MapTag();
         textInputData.putObject("style", new ElementTag(textInput.getStyle()));
-        textInputData.putObject("label", new ElementTag(textInput.getLabel()));
-        textInputData.putObject("id", new ElementTag(textInput.getId()));
+        textInputData.putObject("id", new ElementTag(textInput.getCustomId()));
         if (textInput.getMinLength() != -1) {
             textInputData.putObject("min_length", new ElementTag(textInput.getMinLength()));
         }
@@ -88,10 +87,9 @@ public class DiscordTextInputTag implements ObjectTag {
         if (id == null) {
             return null;
         }
-        ElementTag label = textInputData.getElement("label");
         ElementTag style = textInputData.getElement("style", "SHORT");
         TextInputStyle textInputStyle = style.asEnum(TextInputStyle.class);
-        TextInput.Builder textInput = TextInput.create(id.toString(), label.toString(), textInputStyle);
+        TextInput.Builder textInput = TextInput.create(id.toString(), textInputStyle);
         ElementTag minLength = textInputData.getElement("min_length");
         if (minLength != null) {
             textInput.setMinLength(minLength.asInt());


### PR DESCRIPTION
Updated JDA from 5.0.0-beta.12 to 6.4.1
**Key changes:**
- The dirty hacks in `- discordconnect` are no longer needed and were removed.
- `TextInput`s don't need a `Label` to be created, it's now registered separately when creating a modal.
- `DiscordSelectionTag` ids can no longer be null.
- `#getId()` has changed into `#getCustomId()` and `#getUniqueId()`. Everything uses custom ids, so methods were changed to that.
- `ItemComponent`s have been removed and replaced with `ActionRowChildComponent`s.
- `MessageChannel.retrievePinnedMessages()` returns a list of `PinnedMessage`s rather than `Message`s.
- `Role.getColor()` has been deprecated, moved to `Role.getColors().getPrimary()`. Secondary and Tertiary exist, if there's ever a request for them.