### PR TITLE
DiscordBotTag.custom_status

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordCommand.java
@@ -6,14 +6,14 @@ import com.denizenscript.ddiscordbot.objects.*;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.DenizenCore;
-import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.CoreConfiguration;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.Holdable;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.*;
@@ -51,7 +51,7 @@ public class DiscordCommand extends AbstractCommand implements Holdable {
     // Commands may fail if the bot does not have permission within the Discord group to perform them.
     //
     // When setting the status of the Discord bot, the status argument can be: ONLINE, DND, IDLE, or INVISIBLE,
-    // and the activity argument can be: PLAYING, STREAMING, LISTENING, or WATCHING.
+    // and the activity argument can be: PLAYING, STREAMING, LISTENING, WATCHING, or CUSTOM.
     // Streaming activity requires a 'url:' input.
     //
     // The command should always be ~waited for. See <@link language ~waitable>.
@@ -73,19 +73,19 @@ public class DiscordCommand extends AbstractCommand implements Holdable {
     //
     // @Usage
     // Use to set the online status of the bot, and clear the game status.
-    // - ~discord id:mybot status "Minecraft" "status:ONLINE"
+    // - ~discord id:mybot status Minecraft status:ONLINE
     //
     // @Usage
     // Use to set the game status of the bot.
-    // - ~discord id:mybot status "Minecraft" "status:ONLINE" "activity:PLAYING"
+    // - ~discord id:mybot status Minecraft status:ONLINE activity:PLAYING
     //
     // @Usage
     // Use to change the bot's nickname.
-    // - ~discord id:mybot rename "<[nickname]>" group:<[group]>
+    // - ~discord id:mybot rename <[nickname]> group:<[group]>
     //
     // @Usage
     // Use to give a user a new nickname.
-    // - ~discord id:mybot rename "<[nickname]>" user:<[user]> group:<[group]>
+    // - ~discord id:mybot rename <[nickname]> user:<[user]> group:<[group]>
     //
     // @Usage
     // Use to start typing in a specific channel.
@@ -367,7 +367,7 @@ public class DiscordCommand extends AbstractCommand implements Holdable {
                             return;
                         }
                         Activity at;
-                        String activityType = CoreUtilities.toLowerCase(activity.toString());
+                        String activityType = CoreUtilities.toLowerCase(activity);
                         switch (activityType) {
                             case "watching":
                                 at = Activity.watching(message);
@@ -377,6 +377,9 @@ public class DiscordCommand extends AbstractCommand implements Holdable {
                                 break;
                             case "listening":
                                 at = Activity.listening(message);
+                                break;
+                            case "custom":
+                                at = Activity.of(Activity.ActivityType.CUSTOM_STATUS, message);
                                 break;
                             default:
                                 at = Activity.playing(message);

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordBotTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordBotTag.java
@@ -1,17 +1,16 @@
 package com.denizenscript.ddiscordbot.objects;
 
-import com.denizenscript.ddiscordbot.DenizenDiscordBot;
 import com.denizenscript.ddiscordbot.DiscordConnection;
+import com.denizenscript.ddiscordbot.DenizenDiscordBot;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.Command;
 
@@ -100,7 +99,8 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // Returns the name of the bot.
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
-            return new ElementTag(object.bot, true);
+            return new ElementTag(object.bot);
+
         });
 
         // <--[tag]
@@ -116,6 +116,7 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
                 return null;
             }
             return new DiscordUserTag(object.bot, connection.client.getSelfUser());
+
         });
 
         // <--[tag]
@@ -130,7 +131,11 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
             if (connection == null) {
                 return null;
             }
-            return new ListTag(connection.client.getGuilds(), guild -> new DiscordGroupTag(object.bot, guild));
+            ListTag list = new ListTag();
+            for (Guild guild : connection.client.getGuilds()) {
+                list.addObject(new DiscordGroupTag(object.bot, guild));
+            }
+            return list;
         });
 
         // <--[tag]
@@ -145,7 +150,11 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
             if (connection == null) {
                 return null;
             }
-            return new ListTag(connection.client.retrieveCommands().complete(), command -> new DiscordCommandTag(object.bot, null, command));
+            ListTag list = new ListTag();
+            for (Command command : connection.client.retrieveCommands().complete()) {
+                list.addObject(new DiscordCommandTag(object.bot, null, command));
+            }
+            return list;
         });
 
         // <--[tag]
@@ -155,12 +164,15 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // @description
         // Returns the Discord group (aka 'guild' or 'server') that best matches the input name, or null if there's no match.
         // -->
-        tagProcessor.registerTag(DiscordGroupTag.class, ElementTag.class, "group", (attribute, object, param) -> {
+        tagProcessor.registerTag(DiscordGroupTag.class, "group", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                return null;
+            }
             DiscordConnection connection = object.getConnection();
             if (connection == null) {
                 return null;
             }
-            String matchString = param.asLowerString();
+            String matchString = CoreUtilities.toLowerCase(attribute.getParam());
             Guild bestMatch = null;
             for (Guild guild : connection.client.getGuilds()) {
                 String guildName = CoreUtilities.toLowerCase(guild.getName());
@@ -186,12 +198,15 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // @description
         // Returns the application command that best matches the input name, or null if there's no match.
         // -->
-        tagProcessor.registerTag(DiscordCommandTag.class, ElementTag.class, "command", (attribute, object, param) -> {
+        tagProcessor.registerTag(DiscordCommandTag.class, "command", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                return null;
+            }
             DiscordConnection connection = object.getConnection();
             if (connection == null) {
                 return null;
             }
-            String matchString = param.asLowerString();
+            String matchString = CoreUtilities.toLowerCase(attribute.getParam());
             Command bestMatch = null;
             for (Command command : connection.client.retrieveCommands().complete()) {
                 String commandName = CoreUtilities.toLowerCase(command.getName());
@@ -207,40 +222,6 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
                 return null;
             }
             return new DiscordCommandTag(object.bot, null, bestMatch);
-        });
-
-        // <--[tag]
-        // @attribute <DiscordBotTag.custom_status>
-        // @returns ElementTag
-        // @mechanism DiscordBotTag.custom_status
-        // @plugin dDiscordBot
-        // @description
-        // Returns the custom status of a discord bot, if there is one.
-        // -->
-        tagProcessor.registerTag(ElementTag.class, "custom_status", (attribute, object) -> {
-            DiscordConnection connection = object.getConnection();
-            if (connection == null) {
-                return null;
-            }
-            Activity activity = connection.client.getPresence().getActivity();
-            if (activity == null) {
-                return null;
-            }
-            return new ElementTag(activity.getName(), true);
-        });
-
-        // <--[mechanism]
-        // @object DiscordBotTag
-        // @name custom_status
-        // @input ElementTag
-        // @plugin dDiscordBot
-        // @description
-        // Sets the bot's custom status. Leave blank to unset.
-        // @tags
-        // <DiscordBotTag.custom_status>
-        // -->
-        tagProcessor.registerMechanism("custom_status", false, (object, mechanism) -> {
-            object.getConnection().client.getPresence().setActivity(mechanism.hasValue() ? Activity.of(Activity.ActivityType.CUSTOM_STATUS, mechanism.getValue().asString()) : null);
         });
     }
 

--- a/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordBotTag.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/objects/DiscordBotTag.java
@@ -1,16 +1,17 @@
 package com.denizenscript.ddiscordbot.objects;
 
-import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.ddiscordbot.DenizenDiscordBot;
+import com.denizenscript.ddiscordbot.DiscordConnection;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.commands.Command;
 
@@ -99,8 +100,7 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // Returns the name of the bot.
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
-            return new ElementTag(object.bot);
-
+            return new ElementTag(object.bot, true);
         });
 
         // <--[tag]
@@ -116,7 +116,6 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
                 return null;
             }
             return new DiscordUserTag(object.bot, connection.client.getSelfUser());
-
         });
 
         // <--[tag]
@@ -131,11 +130,7 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
             if (connection == null) {
                 return null;
             }
-            ListTag list = new ListTag();
-            for (Guild guild : connection.client.getGuilds()) {
-                list.addObject(new DiscordGroupTag(object.bot, guild));
-            }
-            return list;
+            return new ListTag(connection.client.getGuilds(), guild -> new DiscordGroupTag(object.bot, guild));
         });
 
         // <--[tag]
@@ -150,11 +145,7 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
             if (connection == null) {
                 return null;
             }
-            ListTag list = new ListTag();
-            for (Command command : connection.client.retrieveCommands().complete()) {
-                list.addObject(new DiscordCommandTag(object.bot, null, command));
-            }
-            return list;
+            return new ListTag(connection.client.retrieveCommands().complete(), command -> new DiscordCommandTag(object.bot, null, command));
         });
 
         // <--[tag]
@@ -164,15 +155,12 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // @description
         // Returns the Discord group (aka 'guild' or 'server') that best matches the input name, or null if there's no match.
         // -->
-        tagProcessor.registerTag(DiscordGroupTag.class, "group", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
+        tagProcessor.registerTag(DiscordGroupTag.class, ElementTag.class, "group", (attribute, object, param) -> {
             DiscordConnection connection = object.getConnection();
             if (connection == null) {
                 return null;
             }
-            String matchString = CoreUtilities.toLowerCase(attribute.getParam());
+            String matchString = param.asLowerString();
             Guild bestMatch = null;
             for (Guild guild : connection.client.getGuilds()) {
                 String guildName = CoreUtilities.toLowerCase(guild.getName());
@@ -198,15 +186,12 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
         // @description
         // Returns the application command that best matches the input name, or null if there's no match.
         // -->
-        tagProcessor.registerTag(DiscordCommandTag.class, "command", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
+        tagProcessor.registerTag(DiscordCommandTag.class, ElementTag.class, "command", (attribute, object, param) -> {
             DiscordConnection connection = object.getConnection();
             if (connection == null) {
                 return null;
             }
-            String matchString = CoreUtilities.toLowerCase(attribute.getParam());
+            String matchString = param.asLowerString();
             Command bestMatch = null;
             for (Command command : connection.client.retrieveCommands().complete()) {
                 String commandName = CoreUtilities.toLowerCase(command.getName());
@@ -222,6 +207,40 @@ public class DiscordBotTag implements ObjectTag, FlaggableObject, Adjustable {
                 return null;
             }
             return new DiscordCommandTag(object.bot, null, bestMatch);
+        });
+
+        // <--[tag]
+        // @attribute <DiscordBotTag.custom_status>
+        // @returns ElementTag
+        // @mechanism DiscordBotTag.custom_status
+        // @plugin dDiscordBot
+        // @description
+        // Returns the custom status of a discord bot, if there is one.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "custom_status", (attribute, object) -> {
+            DiscordConnection connection = object.getConnection();
+            if (connection == null) {
+                return null;
+            }
+            Activity activity = connection.client.getPresence().getActivity();
+            if (activity == null) {
+                return null;
+            }
+            return new ElementTag(activity.getName(), true);
+        });
+
+        // <--[mechanism]
+        // @object DiscordBotTag
+        // @name custom_status
+        // @input ElementTag
+        // @plugin dDiscordBot
+        // @description
+        // Sets the bot's custom status. Leave blank to unset.
+        // @tags
+        // <DiscordBotTag.custom_status>
+        // -->
+        tagProcessor.registerMechanism("custom_status", false, (object, mechanism) -> {
+            object.getConnection().client.getPresence().setActivity(mechanism.hasValue() ? Activity.of(Activity.ActivityType.CUSTOM_STATUS, mechanism.getValue().asString()) : null);
         });
     }
 


### PR DESCRIPTION
Adds `DiscordBotTag.custom_status` tag and mechanism pair to adjust the custom status of bots, and other miscellaneous changes to the DiscordBotTag object type file.

Requested at https://discord.com/channels/315163488085475337/1393978068564967585