### PR TITLE
add `defer_update` and `update` instructions to `discordinteraction`

### DIFF
--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
@@ -51,7 +51,8 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     // 'defer_update' acknowledges a component interaction without a loading state, allowing its original message to be edited later.
     // 'reply' provides the initial interaction response, or sends a followup after the interaction has been acknowledged. It uses similar logic to normal messaging. See <@link command discordmessage>.
     // 'update' immediately updates the message associated with a component interaction as its initial response.
-    // 'edit' edits the interaction's original response through its interaction hook, and 'delete' deletes that original response.
+    // 'edit' edits the interaction's original response through its interaction hook.
+    // 'delete' deletes the interaction's original response through its interaction hook.
     // If you deferred without using 'ephemeral', the 'delete' option will delete the 'Thinking...' message.
     // Ephemeral replies cannot have files.
     //
@@ -77,6 +78,16 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     // Use to defer and reply to an interaction ephemerally.
     // - ~discordinteraction defer interaction:<context.interaction> ephemeral:true
     // - discordinteraction reply interaction:<context.interaction> "Shh, don't tell anyone!"
+    //
+    // @Usage
+    // Use to immediately update the message associated with a component interaction.
+    // - discordinteraction update interaction:<context.interaction> Updated!
+    //
+    // @Usage
+    // Use to silently acknowledge a component interaction, then update its original message later.
+    // - ~discordinteraction defer_update interaction:<context.interaction>
+    // - wait 2s
+    // - discordinteraction edit interaction:<context.interaction> Updated after processing.
     //
     // -->
 
@@ -104,10 +115,10 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
                 yield ((IReplyCallback) interaction.interaction).deferReply(ephemeral);
             }
             case DEFER_UPDATE -> {
-                if (!(interaction.interaction instanceof IMessageEditCallback)) {
+                if (!(interaction.interaction instanceof IMessageEditCallback editCallback)) {
                     throw new InvalidArgumentsRuntimeException("Interaction is not a message edit callback!");
                 }
-                yield ((IMessageEditCallback) interaction.interaction).deferEdit();
+                yield editCallback.deferEdit();
             }
             case EDIT -> {
                 AbstractMessageBuilder<?, ?> messageBuilder = DiscordMessageCommand.createMessageBuilder(scriptEntry, true, false, rows, message, embeds, attachFileName, attachFileText, attachFilesMap);
@@ -126,11 +137,11 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
                 }
             }
             case UPDATE -> {
-                if (!(interaction.interaction instanceof IMessageEditCallback)) {
+                if (!(interaction.interaction instanceof IMessageEditCallback editCallback)) {
                     throw new InvalidArgumentsRuntimeException("Interaction is not a message edit callback!");
                 }
                 AbstractMessageBuilder<?, ?> messageBuilder = DiscordMessageCommand.createMessageBuilder(scriptEntry, true, false, rows, message, embeds, attachFileName, attachFileText, attachFilesMap);
-                yield ((IMessageEditCallback) interaction.interaction).editMessage((MessageEditData) messageBuilder.build());
+                yield editCallback.editMessage((MessageEditData) messageBuilder.build());
             }
             case DELETE -> {
                 yield ((IDeferrableCallback) interaction.interaction).getHook().deleteOriginal();

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
@@ -12,6 +12,7 @@ import com.denizenscript.denizencore.scripts.commands.Holdable;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
+import net.dv8tion.jda.api.interactions.callbacks.IMessageEditCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.*;
@@ -22,7 +23,7 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
 
     public DiscordInteractionCommand() {
         setName("discordinteraction");
-        setSyntax("discordinteraction [defer/reply/edit/delete] [interaction:<interaction>] (ephemeral) (rows:<rows>) (<message>) (embed:<embed>|...) (attach_files:<map>)");
+        setSyntax("discordinteraction [defer/defer_update/reply/update/edit/delete] [interaction:<interaction>] (ephemeral) (rows:<rows>) (<message>) (embed:<embed>|...) (attach_files:<map>)");
         setRequiredArguments(2, 7);
         isProcedural = false;
         autoCompile();
@@ -30,7 +31,7 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
 
     // <--[command]
     // @Name discordinteraction
-    // @Syntax discordinteraction [defer/reply/delete] [interaction:<interaction>] (ephemeral) (rows:<rows>) (<message>) (embed:<embed>|...) (attach_files:<map>)
+    // @Syntax discordinteraction [defer/defer_update/reply/update/edit/delete] [interaction:<interaction>] (ephemeral) (rows:<rows>) (<message>) (embed:<embed>|...) (attach_files:<map>)
     // @Required 2
     // @Maximum 7
     // @Short Manages Discord interactions.
@@ -41,14 +42,17 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     // @Description
     // Manages Discord interactions.
     //
-    // You can defer, reply to, edit, or delete an interaction. These instructions all require the "interaction" argument.
+    // You can defer, defer_update, reply to, update, edit, or delete an interaction. These instructions all require the 'interaction' argument.
     //
-    // The "ephemeral" argument can be used to have the reply message be visible to that one user.
+    // The 'ephemeral' argument can be used to have the reply message be visible to that one user.
     //
-    // You can defer an interaction before replying, which is useful if your reply may take more than a few seconds to be selected.
+    // 'defer' acknowledges an interaction with the normal 'Thinking...' state before a later reply, which is useful if your reply may take more than a few seconds to be selected.
     // If you defer, the 'ephemeral' option can only be set by the defer - you cannot change it with the later reply.
-    // Replying to an interaction uses similar logic to normal messaging. See <@link command discordmessage>.
-    // If you deferred without using 'ephemeral', the 'delete' option will delete the "Thinking..." message.
+    // 'defer_update' acknowledges a component interaction without a loading state, allowing its original message to be edited later.
+    // 'reply' provides the initial interaction response, or sends a followup after the interaction has been acknowledged. It uses similar logic to normal messaging. See <@link command discordmessage>.
+    // 'update' immediately updates the message associated with a component interaction as its initial response.
+    // 'edit' edits the interaction's original response through its interaction hook, and 'delete' deletes that original response.
+    // If you deferred without using 'ephemeral', the 'delete' option will delete the 'Thinking...' message.
     // Ephemeral replies cannot have files.
     //
     // Slash commands, and replies to interactions, have limitations. See <@link url https://gist.github.com/MinnDevelopment/b883b078fdb69d0e568249cc8bf37fe9>.
@@ -62,7 +66,7 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     //
     // @Usage
     // Use to quickly reply to a slash command interaction.
-    // - discordinteraction reply interaction:<context.interaction> "hello!"
+    // - discordinteraction reply interaction:<context.interaction> hello!
     //
     // @Usage
     // Use to defer and reply to a slash command interaction.
@@ -76,7 +80,7 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     //
     // -->
 
-    public enum DiscordInteractionInstruction { DEFER, REPLY, EDIT, DELETE }
+    public enum DiscordInteractionInstruction { DEFER, DEFER_UPDATE, REPLY, UPDATE, EDIT, DELETE }
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("instruction") DiscordInteractionInstruction instruction,
@@ -99,6 +103,12 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
                 }
                 yield ((IReplyCallback) interaction.interaction).deferReply(ephemeral);
             }
+            case DEFER_UPDATE -> {
+                if (!(interaction.interaction instanceof IMessageEditCallback)) {
+                    throw new InvalidArgumentsRuntimeException("Interaction is not a message edit callback!");
+                }
+                yield ((IMessageEditCallback) interaction.interaction).deferEdit();
+            }
             case EDIT -> {
                 AbstractMessageBuilder<?, ?> messageBuilder = DiscordMessageCommand.createMessageBuilder(scriptEntry, true, false, rows, message, embeds, attachFileName, attachFileText, attachFilesMap);
                 InteractionHook hook = ((IDeferrableCallback) interaction.interaction).getHook();
@@ -114,6 +124,13 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
                     IReplyCallback replyTo = (IReplyCallback) interaction.interaction;
                     yield replyTo.reply(messageBuilder.build()).setEphemeral(ephemeral);
                 }
+            }
+            case UPDATE -> {
+                if (!(interaction.interaction instanceof IMessageEditCallback)) {
+                    throw new InvalidArgumentsRuntimeException("Interaction is not a message edit callback!");
+                }
+                AbstractMessageBuilder<?, ?> messageBuilder = DiscordMessageCommand.createMessageBuilder(scriptEntry, true, false, rows, message, embeds, attachFileName, attachFileText, attachFilesMap);
+                yield ((IMessageEditCallback) interaction.interaction).editMessage((MessageEditData) messageBuilder.build());
             }
             case DELETE -> {
                 yield ((IDeferrableCallback) interaction.interaction).getHook().deleteOriginal();

--- a/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
+++ b/src/main/java/com/denizenscript/ddiscordbot/commands/DiscordInteractionCommand.java
@@ -87,7 +87,7 @@ public class DiscordInteractionCommand extends AbstractCommand implements Holdab
     // Use to silently acknowledge a component interaction, then update its original message later.
     // - ~discordinteraction defer_update interaction:<context.interaction>
     // - wait 2s
-    // - discordinteraction edit interaction:<context.interaction> Updated after processing.
+    // - discordinteraction edit interaction:<context.interaction> "Updated after processing."
     //
     // -->
 


### PR DESCRIPTION
### Summary
adds support for the two missing component-interaction response modes to `discordinteraction`; discord thread reference: [(ikuria) discord buttonpress without alert](https://discord.com/channels/315163488085475337/1535693030231769149). this feature request only included one of two missing components, however Discord describes the two callbacks elaborated below as a pair:

- `defer_update` for Discord `DEFERRED_UPDATE_MESSAGE` callback (type `6`)
- `update` for Discord `UPDATE_MESSAGE` callback (type `7`)

these are specifically intended for button/select-menu interactions.
relevant documentation for reference: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object

### Problem

dDiscordBot previously supported normal interaction replies/deferred replies and editing the interaction’s original response, but didn't provide the two component-specific acknowledgement/update paths:
- a component interaction could not be acknowledged without Discord showing the normal deferred-reply loading state
- a component interaction could not immediately update the message it originated from as its initial response

### Changes
- added `defer_update` using JDA’s `IMessageEditCallback.deferEdit()`
  - requires a message-edit-capable interaction
  - acknowledges the component interaction without the normal `Thinking...` state
  - allows the existing `edit` instruction to update the original component message afterwards
- added `update` using JDA’s `IMessageEditCallback.editMessage(MessageEditData)`
  - requires a message-edit-capable interaction
  - immediately edits the original component message as the initial interaction response
- updated `discordinteraction` meta for the new instructions

previously, terms like `defer`, `reply`, and `edit` could be ambiguous; with `defer_update` and `update`, the meta should make that distinction now:
- `defer` is to acknowledge now, reply later
- `defer_update` is to acknowledge a component now, update it's message later
- `reply` is to respond with a message
- `update` is to immediately update the component's message
- `edit` is to edit an already-established interaction response
the change isn't just for the new extra documentation, it makes the command names and their different Discord behaviors easier to understand now

### Testing
- [x] Tested live with Champagne using real Discord buttons:
<img width="204" height="225" alt="image" src="https://github.com/user-attachments/assets/5f69ef8c-b908-4e06-9d75-997a50bfa438" />

- [x] `update`: clicking the test button immediately edited the message containing that button; no followup was created and Discord displayed no interaction failure
- [x] `defer_update`: clicking the test button acknowledged immediately without a visible loading/thinking/typing states; after a two-second delay, existing `edit` updated the same original component message.
- [x] other behaviors tested just to be sure:
  - [x] `defer` followed by `edit`
  - [X] `reply`
  - [x] `delete`

The test-server startup log includes unrelated warnings during startup; the server, Denizen, dDiscordBot, and JDA all completed startup normally; these warnings aren't relevant and don't affect the interaction tests

here's a startup log referencing this test with everything above:
https://files.behr.dev/file-share/dDiscordBot-0.7.1-interaction-updates-latest.log.txt

a working build of my latest successful build which has no errors can be built with this branch or found at:
https://files.behr.dev/file-share/dDiscordBot-0.7.1-interaction-updates.jar